### PR TITLE
Decode HMAC secret

### DIFF
--- a/jedihttp.py
+++ b/jedihttp.py
@@ -17,6 +17,7 @@ utils.AddVendorFolderToSysPath()
 import sys
 import os
 import json
+from base64 import b64decode
 from argparse import ArgumentParser
 from waitress import serve
 from jedihttp import handlers
@@ -54,7 +55,7 @@ def Main():
 
   if args.hmac_file_secret:
     hmac_secret = GetSecretFromTempFile( args.hmac_file_secret )
-    handlers.app.config[ 'jedihttp.hmac_secret' ] = hmac_secret
+    handlers.app.config[ 'jedihttp.hmac_secret' ] = b64decode( hmac_secret )
     handlers.app.install( HmacPlugin() )
 
   serve( handlers.app,

--- a/jedihttp/hmaclib.py
+++ b/jedihttp/hmaclib.py
@@ -31,7 +31,8 @@ def TemporaryHmacSecretFile( secret ):
     The JediHTTP Server as soon as it reads the hmac secret will remove the file
   """
   hmac_file = tempfile.NamedTemporaryFile( 'w', delete = False )
-  json.dump( { 'hmac_secret': secret }, hmac_file )
+  encoded_secret = decode_string( b64encode( encode_string( secret ) ) )
+  json.dump( { 'hmac_secret': encoded_secret }, hmac_file )
   return hmac_file
 
 


### PR DESCRIPTION
We accept a file with a base64 encoded secret but we never decode the
secret and used the ascii base64 encoded version instead. Now we base64
decode the secret.

Fix #11

@Valloric PR for ycmd is coming.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vheon/jedihttp/12)

<!-- Reviewable:end -->
