### PR TITLE
Return completion type in /completions

### DIFF
--- a/jedihttp/handlers.py
+++ b/jedihttp/handlers.py
@@ -59,7 +59,8 @@ def completions():
         'line':        completion.line,
         'column':      completion.column,
         'docstring':   completion.docstring(),
-        'description': completion.description
+        'description': completion.description,
+        'type':        completion.type
       } for completion in script.completions() ]
   } )
 


### PR DESCRIPTION
Jedi has good support for returning the type of proposed completions. This information is pretty useful to any editor integrating Jedi (including YCMD) so I thought I'd just add it very simply here.

For reference: https://github.com/davidhalter/jedi/blob/745184c63b56d1cdc2037b26754ad03088ea17e2/jedi/api/classes.py#L460.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vheon/jedihttp/14)

<!-- Reviewable:end -->
