### PR TITLE
[READY] Add --log option to set logging level

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ If not specified, 127.0.0.1 is used.
 
 Listen on PORT. If not specified, will use any available port.
 
+#### `--log` LEVEL
+
+Set logging level to LEVEL. Available levels, from most verbose to least
+verbose, are: `debug`, `info`, `warning`, `error`, and `critical`. Default value is
+`info`.
+
 #### `--hmac-secret-file` PATH
 
 PATH is the path of a JSON file containing a key named `hmac_secret`. Its value

--- a/jedihttp.py
+++ b/jedihttp.py
@@ -14,9 +14,10 @@
 from jedihttp import utils
 utils.AddVendorFolderToSysPath()
 
-import sys
-import os
+import logging
 import json
+import os
+import sys
 from base64 import b64decode
 from argparse import ArgumentParser
 from waitress import serve
@@ -30,9 +31,23 @@ def ParseArgs():
                        help = 'server host' )
   parser.add_argument( '--port', type = int, default = 0,
                        help = 'server port' )
+  parser.add_argument( '--log', type = str, default = 'info',
+                       choices = [ 'debug', 'info', 'warning',
+                                   'error', 'critical' ],
+                       help = 'log level' )
   parser.add_argument( '--hmac-file-secret', type = str,
                        help = 'file containing hmac secret' )
   return parser.parse_args()
+
+
+def SetUpLogging( log_level ):
+  numeric_level = getattr( logging, log_level.upper(), None )
+  if not isinstance( numeric_level, int ):
+    raise ValueError( 'Invalid log level: {0}'.format( log_level ) )
+
+  # Has to be called before any call to logging.getLogger().
+  logging.basicConfig( format = '%(asctime)s - %(levelname)s - %(message)s',
+                       level = numeric_level )
 
 
 def GetSecretFromTempFile( tfile ):
@@ -52,6 +67,8 @@ def GetSecretFromTempFile( tfile ):
 
 def Main():
   args = ParseArgs()
+
+  SetUpLogging( args.log )
 
   if args.hmac_file_secret:
     hmac_secret = GetSecretFromTempFile( args.hmac_file_secret )


### PR DESCRIPTION
Without this option, we can't see the logs with `debug` level. Also, we need this to pass the `ycmd` logging level to `JediHTTP`.

This is mostly copied from `ycmd`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vheon/jedihttp/15)

<!-- Reviewable:end -->
