### PR TITLE
Move jedihttp.py into jedihttp/

### DIFF
--- a/jedihttp/__main__.py
+++ b/jedihttp/__main__.py
@@ -1,0 +1,8 @@
+from os import path
+import sys
+
+if __package__ is None:
+    sys.path.append( path.abspath( path.join( __file__, '..', '..' ) ) )
+
+from jedihttp import main
+main.Main()

--- a/jedihttp/handlers.py
+++ b/jedihttp/handlers.py
@@ -12,14 +12,14 @@
 #    limitations under the License.
 
 
-from jedihttp import utils
+from . import utils
 utils.AddVendorFolderToSysPath()
 
 import jedi
 import logging
 import json
 import bottle
-from jedihttp import hmaclib
+from . import hmaclib
 from bottle import response, request, Bottle
 from threading import Lock
 

--- a/jedihttp/hmac_plugin.py
+++ b/jedihttp/hmac_plugin.py
@@ -14,7 +14,7 @@
 
 import logging
 from bottle import request, response, abort
-from jedihttp import hmaclib
+from . import hmaclib
 
 try:
   from urlparse import urlparse

--- a/jedihttp/hmaclib.py
+++ b/jedihttp/hmaclib.py
@@ -17,7 +17,7 @@ import hmac
 import hashlib
 import tempfile
 from base64 import b64encode, b64decode
-from jedihttp.compatibility import encode_string, decode_string, compare_digest
+from .compatibility import encode_string, decode_string, compare_digest
 
 
 def TemporaryHmacSecretFile( secret ):

--- a/jedihttp/main.py
+++ b/jedihttp/main.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from jedihttp import utils
+from . import utils
 utils.AddVendorFolderToSysPath()
 
 import logging
@@ -21,8 +21,8 @@ import sys
 from base64 import b64decode
 from argparse import ArgumentParser
 from waitress import serve
-from jedihttp import handlers
-from jedihttp.hmac_plugin import HmacPlugin
+from . import handlers
+from .hmac_plugin import HmacPlugin
 
 
 def ParseArgs():

--- a/jedihttp/tests/end_to_end_test.py
+++ b/jedihttp/tests/end_to_end_test.py
@@ -40,7 +40,7 @@ class HmacAuth( requests.auth.AuthBase ):
 PORT = 50000
 SECRET = 'secret'
 PATH_TO_JEDIHTTP = path.abspath( path.join( path.dirname( __file__ ),
-                                            '..', '..', 'jedihttp.py' ) )
+                                            '..', '__main__.py' ) )
 
 
 def wait_for_jedihttp_to_start( jedihttp ):


### PR DESCRIPTION
It's better not to put Python scripts at the top level. In this PR I keep /jedihttp.py until ycmd has changed, too.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vheon/jedihttp/18)

<!-- Reviewable:end -->
