### PR TITLE
[READY] Add follow_imports option to gotoassignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ Parameters:
   "source": "def f():\n  pass",
   "line": 1,
   "col": 0,
-  "path": "/home/user/code/src/file.py"
+  "path": "/home/user/code/src/file.py",
+  "follow_imports": true, // Optional (default is false)
 }
 ```
 

--- a/jedihttp/handlers.py
+++ b/jedihttp/handlers.py
@@ -84,8 +84,11 @@ def gotodefinition():
 def gotoassignments():
   logger.debug( 'received /gotoassignment request' )
   with jedi_lock:
-    script = _GetJediScript( request.json )
-    response = _FormatDefinitions( script.goto_assignments() )
+    request_json = request.json
+    follow_imports = ( 'follow_imports' in request_json and
+                       request_json[ 'follow_imports' ] )
+    script = _GetJediScript( request_json )
+    response = _FormatDefinitions( script.goto_assignments( follow_imports ) )
   return _JsonResponse( response )
 
 

--- a/jedihttp/tests/fixtures/follow_imports/imported.py
+++ b/jedihttp/tests/fixtures/follow_imports/imported.py
@@ -1,0 +1,2 @@
+def imported_function():
+    pass

--- a/jedihttp/tests/fixtures/follow_imports/importer.py
+++ b/jedihttp/tests/fixtures/follow_imports/importer.py
@@ -1,0 +1,3 @@
+from imported import imported_function
+
+imported_function()

--- a/jedihttp/tests/utils.py
+++ b/jedihttp/tests/utils.py
@@ -69,9 +69,9 @@ def with_jedihttp( setup, teardown ):
   return decorate
 
 
-def fixture_filepath( filename ):
+def fixture_filepath( *components ):
   dir_of_current_script = os.path.dirname( os.path.abspath( __file__ ) )
-  return os.path.join( dir_of_current_script, 'fixtures', filename )
+  return os.path.join( dir_of_current_script, 'fixtures', *components )
 
 
 # Creation flag to disable creating a console window on Windows. See


### PR DESCRIPTION
Jedi recently added the `follow_imports` option to [the `gotoassignments` method](http://jedi.jedidjah.ch/en/latest/docs/plugin-api.html#jedi.api.Script.goto_assignments). We will definitely use this option in ycmd.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vheon/jedihttp/22)

<!-- Reviewable:end -->
