### PR TITLE
[READY] Add /preload_module endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,22 @@ Response:
 }
 ```
 
+### POST /preload_module
+
+Parameters:
+
+```javascript
+{
+  "modules": [ "numpy", ... ]
+}
+```
+
+Response:
+
+```javascript
+true
+```
+
 ### In case of errors
 
 Response:

--- a/jedihttp/handlers.py
+++ b/jedihttp/handlers.py
@@ -100,6 +100,14 @@ def names():
   return _JsonResponse( response )
 
 
+@app.post( '/preload_module' )
+def preload_module():
+  logger.debug( 'received /preload_module request' )
+  with jedi_lock:
+    jedi.preload_module( *request.json[ 'modules' ] )
+  return _JsonResponse( True )
+
+
 def _FormatCompletions( completions ):
   return {
       'completions': [ {

--- a/jedihttp/tests/handlers_test.py
+++ b/jedihttp/tests/handlers_test.py
@@ -347,6 +347,15 @@ def test_names():
   ) )
 
 
+def test_preload_module():
+  app = TestApp( handlers.app )
+  request_data = {
+      'modules': [ 'os', 'sys' ]
+  }
+
+  ok_( app.post_json( '/preload_module', request_data ) )
+
+
 @py3only
 def test_py3():
   app = TestApp( handlers.app )


### PR DESCRIPTION
Expose [the preload_module function](http://jedi.jedidjah.ch/en/latest/docs/plugin-api.html#jedi.api.preload_module).

I named the new route `/preload_module` and not `/preloadmodule` because I find it more readable and it's closer to Jedi API. I would suggest to do the same for the goto routes by adding `/goto_definition` and `/goto_assignment` and deprecate the old ones. What do you think?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vheon/jedihttp/24)

<!-- Reviewable:end -->
