### PR TITLE
[READY] Add field to customize Jedi settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Listen on PORT. If not specified, will use any available port.
 #### `--log` LEVEL
 
 Set logging level to LEVEL. Available levels, from most verbose to least
-verbose, are: `debug`, `info`, `warning`, `error`, and `critical`. Default value is
-`info`.
+verbose, are: `debug`, `info`, `warning`, `error`, and `critical`. Default value
+is `info`.
 
 #### `--hmac-secret-file` PATH
 
@@ -67,7 +67,11 @@ Parameters:
   "source": "def f():\n  pass",
   "line": 1,
   "col": 0,
-  "path": "/home/user/code/src/file.py"
+  "path": "/home/user/code/src/file.py",
+  "settings": {
+    "add_bracket_after_function": true,
+    ...
+  } // Jedi settings. Optional.
 }
 ```
 
@@ -99,7 +103,8 @@ Parameters:
   "source": "def f():\n  pass",
   "line": 1,
   "col": 0,
-  "path": "/home/user/code/src/file.py"
+  "path": "/home/user/code/src/file.py",
+  "settings": {} // Jedi settings. Optional.
 }
 ```
 
@@ -111,6 +116,7 @@ Response:
     {
       "module_path": "/usr/lib/python2.7/os.py", // Shows the file path of a module.
       "name": "name", // Name of variable/function/class/module.
+      "type": "type", // Type of the completion (module, class, instance, etc.)
       "line": 3,  // The line where the definition occurs (starting with 1).
       "column": 1, // The column where the definition occurs (starting with 0).
       "in_builtin_module": false, // Whether this is a builtin module.
@@ -134,7 +140,8 @@ Parameters:
   "line": 1,
   "col": 0,
   "path": "/home/user/code/src/file.py",
-  "follow_imports": true, // Optional (default is false)
+  "follow_imports": true, // Optional (default is false).
+  "settings": {} // Jedi settings. Optional.
 }
 ```
 
@@ -146,6 +153,7 @@ Response:
     {
       "module_path": "/usr/lib/python2.7/os.py", // Shows the file path of a module.
       "name": "name", // Name of variable/function/class/module.
+      "type": "type", // Type of the completion (module, class, instance, etc.)
       "line": 3,  // The line where the definition occurs (starting with 1).
       "column": 1 // The column where the definition occurs (starting with 0).
       "in_builtin_module": false, // Whether this is a builtin module.
@@ -168,7 +176,10 @@ Parameters:
   "source": "def f():\n  pass\n\na = f()\nb = f()",
   "line": 1,
   "col": 4,
-  "path": "/home/user/code/src/file.py"
+  "path": "/home/user/code/src/file.py",
+  "settings": {
+    "additional_dynamic_modules": "/path/to/a/file.py"
+  } // Jedi settings. Optional.
 }
 ```
 
@@ -225,9 +236,10 @@ Parameters:
 {
   "source": "import os\n\nCONSTANT = 1\n\ndef test():\n  pass",
   "path": "/home/user/code/src/file.py"
-  "all_scopes": false, // Optional (default is false)
-  "definitions": true, // Optional (default is true)
-  "references": false // Optional (default is false)
+  "all_scopes": false, // Optional (default is false).
+  "definitions": true, // Optional (default is true).
+  "references": false, // Optional (default is false).
+  "settings": {} // Jedi settings. Optional.
 }
 ```
 

--- a/jedihttp/compatibility.py
+++ b/jedihttp/compatibility.py
@@ -58,3 +58,15 @@ else:
 
 def compare_digest( a, b ):
   return SecureStringsEqual( a, b )
+
+
+try:
+  dict.iteritems
+except AttributeError:
+  # Python 3
+  def iteritems( dictionary ):
+    return iter( dictionary.items() )
+else:
+  # Python 2
+  def iteritems( dictionary ):
+    return dictionary.iteritems()

--- a/jedihttp/handlers.py
+++ b/jedihttp/handlers.py
@@ -15,12 +15,14 @@
 from jedihttp import utils
 utils.AddVendorFolderToSysPath()
 
+import contextlib
 import jedi
 import logging
 import json
 import bottle
-from jedihttp import hmaclib
 from bottle import response, request, Bottle
+from jedihttp import hmaclib
+from jedihttp.compatibility import iteritems
 from threading import Lock
 
 try:
@@ -39,6 +41,26 @@ app = Bottle( __name__ )
 # Jedi is not thread safe.
 jedi_lock = Lock()
 
+# For efficiency, we store the default values of the global Jedi settings. See
+# https://jedi.readthedocs.io/en/latest/docs/settings.html
+default_settings = {
+    'case_insensitive_completion'     :
+        jedi.settings.case_insensitive_completion,
+    'add_bracket_after_function'      :
+        jedi.settings.add_bracket_after_function,
+    'no_completion_duplicates'        : jedi.settings.no_completion_duplicates,
+    'cache_directory'                 : jedi.settings.cache_directory,
+    'use_filesystem_cache'            : jedi.settings.cache_directory,
+    'fast_parser'                     : jedi.settings.fast_parser,
+    'dynamic_array_additions'         : jedi.settings.dynamic_array_additions,
+    'dynamic_params'                  : jedi.settings.dynamic_params,
+    'dynamic_params_for_other_modules':
+        jedi.settings.dynamic_params_for_other_modules,
+    'additional_dynamic_modules'      :
+        jedi.settings.additional_dynamic_modules,
+    'auto_import_modules'             : jedi.settings.auto_import_modules
+}
+
 
 @app.post( '/healthy' )
 def healthy():
@@ -56,8 +78,10 @@ def ready():
 def completions():
   logger.debug( 'received /completions request' )
   with jedi_lock:
-    script = _GetJediScript( request.json )
-    response = _FormatCompletions( script.completions() )
+    request_json = request.json
+    with _CustomSettings( request_json ):
+      script = _GetJediScript( request_json )
+      response = _FormatCompletions( script.completions() )
   return _JsonResponse( response )
 
 
@@ -65,8 +89,10 @@ def completions():
 def gotodefinition():
   logger.debug( 'received /gotodefinition request' )
   with jedi_lock:
-    script = _GetJediScript( request.json )
-    response = _FormatDefinitions( script.goto_definitions() )
+    request_json = request.json
+    with _CustomSettings( request_json ):
+      script = _GetJediScript( request_json )
+      response = _FormatDefinitions( script.goto_definitions() )
   return _JsonResponse( response )
 
 
@@ -75,10 +101,10 @@ def gotoassignments():
   logger.debug( 'received /gotoassignment request' )
   with jedi_lock:
     request_json = request.json
-    follow_imports = ( 'follow_imports' in request_json and
-                       request_json[ 'follow_imports' ] )
-    script = _GetJediScript( request_json )
-    response = _FormatDefinitions( script.goto_assignments( follow_imports ) )
+    follow_imports = request_json.get( 'follow_imports', False )
+    with _CustomSettings( request_json ):
+      script = _GetJediScript( request_json )
+      response = _FormatDefinitions( script.goto_assignments( follow_imports ) )
   return _JsonResponse( response )
 
 
@@ -86,8 +112,10 @@ def gotoassignments():
 def usages():
   logger.debug( 'received /usages request' )
   with jedi_lock:
-    script = _GetJediScript( request.json )
-    response = _FormatDefinitions( script.usages() )
+    request_json = request.json
+    with _CustomSettings( request_json ):
+      script = _GetJediScript( request_json )
+      response = _FormatDefinitions( script.usages() )
   return _JsonResponse( response )
 
 
@@ -95,8 +123,10 @@ def usages():
 def names():
   logger.debug( 'received /names request' )
   with jedi_lock:
-    definitions = _GetJediNames( request.json )
-    response = _FormatDefinitions( definitions )
+    request_json = request.json
+    with _CustomSettings( request_json ):
+      definitions = _GetJediNames( request_json )
+      response = _FormatDefinitions( definitions )
   return _JsonResponse( response )
 
 
@@ -104,7 +134,9 @@ def names():
 def preload_module():
   logger.debug( 'received /preload_module request' )
   with jedi_lock:
-    jedi.preload_module( *request.json[ 'modules' ] )
+    request_json = request.json
+    with _CustomSettings( request_json ):
+      jedi.preload_module( *request_json[ 'modules' ] )
   return _JsonResponse( True )
 
 
@@ -152,6 +184,24 @@ def _GetJediNames( request_data ):
                      all_scopes = request_data.get( 'all_scopes', False ),
                      definitions = request_data.get( 'definitions', True ),
                      references = request_data.get( 'references', False ) )
+
+
+def _SetJediSettings( settings ):
+  for name, value in iteritems( settings ):
+    setattr( jedi.settings, name, value )
+
+
+@contextlib.contextmanager
+def _CustomSettings( request_data ):
+  settings = request_data.get( 'settings' )
+  if not settings:
+    yield
+    return
+  try:
+    _SetJediSettings( settings )
+    yield
+  finally:
+    _SetJediSettings( default_settings )
 
 
 @app.error( httplib.INTERNAL_SERVER_ERROR )

--- a/jedihttp/tests/fixtures/module/main.py
+++ b/jedihttp/tests/fixtures/module/main.py
@@ -1,0 +1,5 @@
+from some_module.file1 import FILE1_CONSTANT
+
+
+def main_function():
+    return FILE1_CONSTANT

--- a/jedihttp/tests/fixtures/module/some_module/file1.py
+++ b/jedihttp/tests/fixtures/module/some_module/file1.py
@@ -1,0 +1,5 @@
+FILE1_CONSTANT = 'test'
+
+
+def file1_function():
+    return FILE1_CONSTANT

--- a/jedihttp/tests/fixtures/module/some_module/file2.py
+++ b/jedihttp/tests/fixtures/module/some_module/file2.py
@@ -1,0 +1,5 @@
+from file1 import FILE1_CONSTANT
+
+
+def file2_function():
+    return FILE1_CONSTANT

--- a/jedihttp/tests/fixtures/module/some_module/main.py
+++ b/jedihttp/tests/fixtures/module/some_module/main.py
@@ -1,0 +1,1 @@
+from some_module.

--- a/jedihttp/utils.py
+++ b/jedihttp/utils.py
@@ -16,9 +16,7 @@ import sys
 
 
 def AddVendorFolderToSysPath():
-  vendor_folder = os.path.join( os.path.dirname( __file__ ),
-                                '..',
-                                'vendor' )
+  vendor_folder = os.path.join( os.path.dirname( __file__ ), '..', 'vendor' )
 
   for folder in os.listdir( vendor_folder ):
     sys.path.insert( 0, os.path.realpath( os.path.join( vendor_folder,


### PR DESCRIPTION
This PR allows customization of [the global Jedi settings](https://jedi.readthedocs.io/en/latest/docs/settings.html) by specifying the optional `settings` field in a request. This field is available for all endpoints except the `healthy` and `ready` ones where it is not needed.

When the `settings` field is given, the global Jedi settings are only modified during the request. At the end of the request, the settings are reverted to their default values. This makes it possible to use JediHTTP with different sets of settings; one for each Python project for instance.

I added a test that is a practical example of how this new feature can be useful: by setting the `additional_dynamic_modules` option, we can find references of a symbol that are not in the current module or the imported modules. This is the option that we will use to improve the `GoToReferences` command and to implement [the `RefactorRename` command in ycmd](https://github.com/Valloric/ycmd/pull/425).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vheon/jedihttp/25)
<!-- Reviewable:end -->
