### PR TITLE
[READY] Fix unclosed file warnings on Python 3

### DIFF
--- a/jedihttp/tests/end_to_end_test.py
+++ b/jedihttp/tests/end_to_end_test.py
@@ -13,7 +13,7 @@
 
 
 from . import utils
-from .utils import with_jedihttp, py2only
+from .utils import with_jedihttp, py2only, read_file
 import requests
 import subprocess
 from jedihttp import hmaclib
@@ -88,7 +88,7 @@ def test_client_request_with_parameters( jedihttp ):
 
   filepath = utils.fixture_filepath( 'goto.py' )
   request_data = {
-      'source': open( filepath ).read(),
+      'source': read_file( filepath ),
       'line': 10,
       'col': 3,
       'source_path': filepath
@@ -112,7 +112,7 @@ def test_client_bad_request_with_parameters( jedihttp ):
 
   filepath = utils.fixture_filepath( 'goto.py' )
   request_data = {
-      'source': open( filepath ).read(),
+      'source': read_file( filepath ),
       'line': 100,
       'col': 1,
       'source_path': filepath
@@ -137,7 +137,7 @@ def test_client_python3_specific_syntax_completion( jedihttp ):
 
   filepath = utils.fixture_filepath( 'py3.py' )
   request_data = {
-      'source': open( filepath ).read(),
+      'source': read_file( filepath ),
       'line': 19,
       'col': 11,
       'source_path': filepath

--- a/jedihttp/tests/handlers_test.py
+++ b/jedihttp/tests/handlers_test.py
@@ -14,7 +14,7 @@
 
 from __future__ import absolute_import
 
-from .utils import fixture_filepath, py3only
+from .utils import fixture_filepath, py3only, read_file
 from webtest import TestApp
 from jedihttp import handlers
 from nose.tools import ok_
@@ -52,7 +52,7 @@ def test_completion():
   app = TestApp( handlers.app )
   filepath = fixture_filepath( 'basic.py' )
   request_data = {
-      'source': open( filepath ).read(),
+      'source': read_file( filepath ),
       'line': 7,
       'col': 2,
       'source_path': filepath
@@ -70,7 +70,7 @@ def test_good_gotodefinition():
   app = TestApp( handlers.app )
   filepath = fixture_filepath( 'goto.py' )
   request_data = {
-      'source': open( filepath ).read(),
+      'source': read_file( filepath ),
       'line': 10,
       'col': 3,
       'source_path': filepath
@@ -112,7 +112,7 @@ def test_bad_gotodefinitions_blank_line():
   app = TestApp( handlers.app )
   filepath = fixture_filepath( 'goto.py' )
   request_data = {
-      'source': open( filepath ).read(),
+      'source': read_file( filepath ),
       'line': 9,
       'col': 1,
       'source_path': filepath
@@ -126,7 +126,7 @@ def test_bad_gotodefinitions_not_on_valid_position():
   app = TestApp( handlers.app )
   filepath = fixture_filepath( 'goto.py' )
   request_data = {
-      'source': open( filepath ).read(),
+      'source': read_file( filepath ),
       'line': 100,
       'col': 1,
       'source_path': filepath
@@ -141,7 +141,7 @@ def test_good_gotoassignment():
   app = TestApp( handlers.app )
   filepath = fixture_filepath( 'goto.py' )
   request_data = {
-      'source': open( filepath ).read(),
+      'source': read_file( filepath ),
       'line': 20,
       'col': 1,
       'source_path': filepath
@@ -168,7 +168,7 @@ def test_good_gotoassignment_do_not_follow_imports():
   app = TestApp( handlers.app )
   filepath = fixture_filepath( 'follow_imports', 'importer.py' )
   request_data = {
-      'source': open( filepath ).read(),
+      'source': read_file( filepath ),
       'line': 3,
       'col': 9,
       'source_path': filepath
@@ -204,7 +204,7 @@ def test_good_gotoassignment_follow_imports():
   importer_filepath = fixture_filepath( 'follow_imports', 'importer.py' )
   imported_filepath = fixture_filepath( 'follow_imports', 'imported.py' )
   request_data = {
-      'source': open( importer_filepath ).read(),
+      'source': read_file( importer_filepath ),
       'line': 3,
       'col': 9,
       'source_path': importer_filepath,
@@ -232,7 +232,7 @@ def test_usages():
   app = TestApp( handlers.app )
   filepath = fixture_filepath( 'usages.py' )
   request_data = {
-      'source': open( filepath ).read(),
+      'source': read_file( filepath ),
       'line': 8,
       'col': 5,
       'source_path': filepath
@@ -298,7 +298,7 @@ def test_names():
   app = TestApp( handlers.app )
   filepath = fixture_filepath( 'names.py' )
   request_data = {
-      'source': open( filepath ).read(),
+      'source': read_file( filepath ),
       'path': filepath,
       'all_scopes': False,
       'definitions': True,
@@ -362,7 +362,7 @@ def test_usages_settings_additional_dynamic_modules():
   file2 = fixture_filepath( 'module', 'some_module', 'file2.py' )
   main_file = fixture_filepath( 'module', 'main.py' )
   request_data = {
-      'source': open( file2 ).read(),
+      'source': read_file( file2 ),
       'line': 5,
       'col': 17,
       'source_path': file2,
@@ -419,7 +419,7 @@ def test_py3():
   app = TestApp( handlers.app )
   filepath = fixture_filepath( 'py3.py' )
   request_data = {
-      'source': open( filepath ).read(),
+      'source': read_file( filepath ),
       'line': 19,
       'col': 11,
       'source_path': filepath

--- a/jedihttp/tests/utils.py
+++ b/jedihttp/tests/utils.py
@@ -74,6 +74,13 @@ def fixture_filepath( *components ):
   return os.path.join( dir_of_current_script, 'fixtures', *components )
 
 
+# Python 3 complains on the common open(path).read() idiom because the file
+# doesn't get closed.
+def read_file( filepath ):
+  with open( filepath ) as f:
+    return f.read()
+
+
 # Creation flag to disable creating a console window on Windows. See
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms684863.aspx
 CREATE_NO_WINDOW = 0x08000000


### PR DESCRIPTION
Tests are raising warnings on Python 3 because files are not closed. Add the `read_file` function to handle that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vheon/jedihttp/29)
<!-- Reviewable:end -->
