### PR TITLE
[READY] Fix tests on Python 2.6

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,6 @@
-flake8>=2.0
-nose>=1.3.0
-WebTest>=2.0.0
-PyHamcrest>=1.8.0
-requests>=2.8.1
+flake8     >= 2.0
+nose       >= 1.3.0
+# WebTest 2.0.24 dropped support of Python 2.6
+WebTest    >= 2.0.0, < 2.0.24
+PyHamcrest >= 1.8.0
+requests   >= 2.8.1


### PR DESCRIPTION
Tests are failing on Python 2.6 because WebTest removed its 2.6 compatibility shim for `OrderedDict`:
```
Traceback (most recent call last):
  File "/home/travis/build/vheon/JediHTTP/.tox/py26/lib/python2.6/site-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/home/travis/build/vheon/JediHTTP/.tox/py26/lib/python2.6/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/home/travis/build/vheon/JediHTTP/.tox/py26/lib/python2.6/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/travis/build/vheon/JediHTTP/jedihttp/tests/handlers_test.py", line 18, in <module>
    from webtest import TestApp
  File "/home/travis/build/vheon/JediHTTP/.tox/py26/lib/python2.6/site-packages/webtest/__init__.py", line 9, in <module>
    from webtest.app import TestApp
  File "/home/travis/build/vheon/JediHTTP/.tox/py26/lib/python2.6/site-packages/webtest/app.py", line 32, in <module>
    from webtest.response import TestResponse
  File "/home/travis/build/vheon/JediHTTP/.tox/py26/lib/python2.6/site-packages/webtest/response.py", line 5, in <module>
    from webtest import forms
  File "/home/travis/build/vheon/JediHTTP/.tox/py26/lib/python2.6/site-packages/webtest/forms.py", line 8, in <module>
    from collections import OrderedDict
ImportError: cannot import name OrderedDict
```
Since [WebTest officially dropped support of Python 2.6 in version 2.0.24](https://github.com/Pylons/webtest/commit/d4323df046ce1ed4694fdd49f2abd7008fb016ae), we require an older version for our tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vheon/jedihttp/32)
<!-- Reviewable:end -->
