### PR TITLE
[READY] Improve socket completion on Python 2

### DIFF
--- a/jedihttp/handlers.py
+++ b/jedihttp/handlers.py
@@ -23,6 +23,7 @@ import bottle
 from bottle import response, request, Bottle
 from jedihttp import hmaclib
 from jedihttp.compatibility import iteritems
+from jedihttp.settings import default_settings
 from threading import Lock
 
 try:
@@ -40,26 +41,6 @@ app = Bottle( __name__ )
 
 # Jedi is not thread safe.
 jedi_lock = Lock()
-
-# For efficiency, we store the default values of the global Jedi settings. See
-# https://jedi.readthedocs.io/en/latest/docs/settings.html
-default_settings = {
-    'case_insensitive_completion'     :
-        jedi.settings.case_insensitive_completion,
-    'add_bracket_after_function'      :
-        jedi.settings.add_bracket_after_function,
-    'no_completion_duplicates'        : jedi.settings.no_completion_duplicates,
-    'cache_directory'                 : jedi.settings.cache_directory,
-    'use_filesystem_cache'            : jedi.settings.cache_directory,
-    'fast_parser'                     : jedi.settings.fast_parser,
-    'dynamic_array_additions'         : jedi.settings.dynamic_array_additions,
-    'dynamic_params'                  : jedi.settings.dynamic_params,
-    'dynamic_params_for_other_modules':
-        jedi.settings.dynamic_params_for_other_modules,
-    'additional_dynamic_modules'      :
-        jedi.settings.additional_dynamic_modules,
-    'auto_import_modules'             : jedi.settings.auto_import_modules
-}
 
 
 @app.post( '/healthy' )

--- a/jedihttp/settings.py
+++ b/jedihttp/settings.py
@@ -1,0 +1,42 @@
+#     Copyright 2017 Cedraro Andrea <a.cedraro@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import jedi
+import sys
+
+# For efficiency, we store the default values of the global Jedi settings. See
+# https://jedi.readthedocs.io/en/latest/docs/settings.html
+
+auto_import_modules = jedi.settings.auto_import_modules
+# The socket module uses setattr for several methods (connect, listen, etc.) on
+# Python 2.
+if sys.version_info < ( 3, 0 ):
+  auto_import_modules.append( 'socket' )
+
+default_settings = {
+    'case_insensitive_completion'     :
+        jedi.settings.case_insensitive_completion,
+    'add_bracket_after_function'      :
+        jedi.settings.add_bracket_after_function,
+    'no_completion_duplicates'        : jedi.settings.no_completion_duplicates,
+    'cache_directory'                 : jedi.settings.cache_directory,
+    'use_filesystem_cache'            : jedi.settings.cache_directory,
+    'fast_parser'                     : jedi.settings.fast_parser,
+    'dynamic_array_additions'         : jedi.settings.dynamic_array_additions,
+    'dynamic_params'                  : jedi.settings.dynamic_params,
+    'dynamic_params_for_other_modules':
+        jedi.settings.dynamic_params_for_other_modules,
+    'additional_dynamic_modules'      :
+        jedi.settings.additional_dynamic_modules,
+    'auto_import_modules'             : auto_import_modules
+}

--- a/jedihttp/tests/fixtures/socket_module.py
+++ b/jedihttp/tests/fixtures/socket_module.py
@@ -1,0 +1,4 @@
+import socket
+
+s = socket.socket()
+s.co

--- a/jedihttp/tests/handlers_test.py
+++ b/jedihttp/tests/handlers_test.py
@@ -431,3 +431,20 @@ def test_py3():
   assert_that( completions, has_item( CompletionEntry( 'values' ) ) )
   assert_that( completions,
                is_not( has_item( CompletionEntry( 'itervalues' ) ) ) )
+
+
+def test_completion_socket_module():
+  app = TestApp( handlers.app )
+  filepath = fixture_filepath( 'socket_module.py' )
+  request_data = {
+      'source': read_file( filepath ),
+      'line': 4,
+      'col': 4,
+      'source_path': filepath
+  }
+
+  completions = app.post_json( '/completions',
+                                request_data ).json[ 'completions' ]
+
+  assert_that( completions, has_items( CompletionEntry( 'connect' ),
+                                       CompletionEntry( 'connect_ex' ) ) )


### PR DESCRIPTION
See discussion in https://github.com/Valloric/YouCompleteMe/issues/2562.

One downside of adding a module to the `auto_import_modules` setting is that it makes the module as a built in one and so it cannot be jumped to. I think proper completions outweigh the ability to jump (I rarely want to jump into a module of the standard library) but you may disagree.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vheon/jedihttp/33)
<!-- Reviewable:end -->
