### PR TITLE
[READY] Update Jedi to latest commit

### DIFF
--- a/jedihttp/tests/handlers_test.py
+++ b/jedihttp/tests/handlers_test.py
@@ -18,7 +18,7 @@ from .utils import fixture_filepath, py3only, read_file
 from webtest import TestApp
 from jedihttp import handlers
 from nose.tools import ok_
-from hamcrest import ( assert_that, only_contains, contains,
+from hamcrest import ( assert_that, only_contains, contains, contains_string,
                        contains_inanyorder, all_of, is_not, has_key, has_item,
                        has_items, has_entry, has_entries, equal_to, is_, empty )
 
@@ -180,7 +180,7 @@ def test_good_gotoassignment_do_not_follow_imports():
       'in_builtin_module': False,
       'line': 1,
       'column': 21,
-      'docstring': '',
+      'docstring': 'imported_function()\n\n',
       'description': 'def imported_function',
       'full_name': 'imported.imported_function',
       'is_keyword': False
@@ -308,19 +308,19 @@ def test_names():
   definitions = app.post_json( '/names', request_data ).json[ 'definitions' ]
 
   assert_that( definitions, contains_inanyorder(
-      {
+      has_entries( {
         'module_path': filepath,
         'name': 'os',
         'type': 'module',
         'in_builtin_module': False,
         'line': 1,
         'column': 7,
-        'docstring': '',
+        'docstring': contains_string( 'OS routines' ),
         'description': 'module os',
         'full_name': 'os',
         'is_keyword': False
-      },
-      {
+      } ),
+      has_entries( {
         'module_path': filepath,
         'name': 'CONSTANT',
         'type': 'statement',
@@ -331,8 +331,8 @@ def test_names():
         'description': 'CONSTANT = 1',
         'full_name': 'names.CONSTANT',
         'is_keyword': False
-      },
-      {
+      } ),
+      has_entries( {
         'module_path': filepath,
         'name': 'test',
         'type': 'function',
@@ -343,7 +343,7 @@ def test_names():
         'description': 'def test',
         'full_name': 'names.test',
         'is_keyword': False
-      },
+      } )
   ) )
 
 


### PR DESCRIPTION
Current version of Jedi may return an empty docstring when completing in the middle of a function. For instance, the following code that completes the `get` function from `requests` and prints its docstring:
```python
import jedi
import pprint

args = (
  '''import requests
requests.ge
''',
  2,
  len( 'requests.ge' ),
  'example.py'
)

for completion in jedi.Script(*args).completions():
     pprint.pprint( completion.docstring() )

args = (
  '''import requests
requests.get
''',
  2,
  len( 'requests.get' ),
  'example.py'
)

for completion in jedi.Script(*args).completions():
     pprint.pprint( completion.docstring() )
```
will output:
```
''
('get(url, params=None, **kwargs)\n'
 '\n'
 'Sends a GET request.\n'
 '\n'
 ':param url: URL for the new :class:`Request` object.\n'
 ':param params: (optional) Dictionary or bytes to be sent in the query string '
 'for the :class:`Request`.\n'
 ':param \\*\\*kwargs: Optional arguments that ``request`` takes.\n'
 ':return: :class:`Response <Response>` object\n'
 ':rtype: requests.Response')
```
The docstring is empty after completing `ge` but not after `get`. This issue was fixed in commit https://github.com/davidhalter/jedi/commit/7ca62578e11031ae09a6ad79fd74089de25ed46d. We update the Jedi dependency to include the commit.

In addition, we update the tests as latest Jedi version seems to have improved its docstring parsing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vheon/jedihttp/35)
<!-- Reviewable:end -->
