### PR TITLE
[READY] Fix use_filesystem_cache setting

### DIFF
--- a/jedihttp/settings.py
+++ b/jedihttp/settings.py
@@ -30,7 +30,7 @@ default_settings = {
         jedi.settings.add_bracket_after_function,
     'no_completion_duplicates'        : jedi.settings.no_completion_duplicates,
     'cache_directory'                 : jedi.settings.cache_directory,
-    'use_filesystem_cache'            : jedi.settings.cache_directory,
+    'use_filesystem_cache'            : jedi.settings.use_filesystem_cache,
     'fast_parser'                     : jedi.settings.fast_parser,
     'dynamic_array_additions'         : jedi.settings.dynamic_array_additions,
     'dynamic_params'                  : jedi.settings.dynamic_params,


### PR DESCRIPTION
`use_filesystem_cache` is set to the wrong Jedi default setting. This doesn't lead to any strange behavior since the `cache_directory` default setting is as truthy as the `use_filesystem_cache` one but still, this should be fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vheon/jedihttp/37)
<!-- Reviewable:end -->
