### PR TITLE
[READY] Follow PEP8 code style

### DIFF
--- a/jedihttp.py
+++ b/jedihttp.py
@@ -12,7 +12,7 @@
 #    limitations under the License.
 
 from jedihttp import utils
-utils.AddVendorFolderToSysPath()
+utils.add_vendor_folder_to_sys_path()
 
 import logging
 import json
@@ -25,59 +25,60 @@ from jedihttp import handlers
 from jedihttp.hmac_plugin import HmacPlugin
 
 
-def ParseArgs():
-  parser = ArgumentParser()
-  parser.add_argument( '--host', type = str, default = '127.0.0.1',
-                       help = 'server host' )
-  parser.add_argument( '--port', type = int, default = 0,
-                       help = 'server port' )
-  parser.add_argument( '--log', type = str, default = 'info',
-                       choices = [ 'debug', 'info', 'warning',
-                                   'error', 'critical' ],
-                       help = 'log level' )
-  parser.add_argument( '--hmac-file-secret', type = str,
-                       help = 'file containing hmac secret' )
-  return parser.parse_args()
+def parse_args():
+    parser = ArgumentParser()
+    parser.add_argument('--host', type=str, default='127.0.0.1',
+                        help='server host')
+    parser.add_argument('--port', type=int, default=0,
+                        help='server port')
+    parser.add_argument('--log', type=str, default='info',
+                        choices=['debug', 'info', 'warning', 'error',
+                                 'critical'],
+                        help='log level')
+    parser.add_argument('--hmac-file-secret', type=str,
+                        help='file containing hmac secret')
+    return parser.parse_args()
 
 
-def SetUpLogging( log_level ):
-  numeric_level = getattr( logging, log_level.upper(), None )
-  if not isinstance( numeric_level, int ):
-    raise ValueError( 'Invalid log level: {0}'.format( log_level ) )
+def set_up_logging(log_level):
+    numeric_level = getattr(logging, log_level.upper(), None)
+    if not isinstance(numeric_level, int):
+        raise ValueError('Invalid log level: {0}'.format(log_level))
 
-  # Has to be called before any call to logging.getLogger().
-  logging.basicConfig( format = '%(asctime)s - %(levelname)s - %(message)s',
-                       level = numeric_level )
-
-
-def GetSecretFromTempFile( tfile ):
-  key = 'hmac_secret'
-  with open( tfile ) as hmac_file:
-    try:
-      data = json.load( hmac_file )
-      if key not in data:
-        sys.exit( "A json file with a key named 'secret' was expected for "
-                  "the secret exchange, but wasn't found" )
-      hmac_secret = data[ key ]
-    except ValueError:
-      sys.exit( "A JSON was expected for the secret exchange" )
-  os.remove( tfile )
-  return hmac_secret
+    # Has to be called before any call to logging.getLogger().
+    logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s',
+                        level=numeric_level)
 
 
-def Main():
-  args = ParseArgs()
+def get_secret_from_temp_file(tfile):
+    key = 'hmac_secret'
+    with open(tfile) as hmac_file:
+        try:
+            data = json.load(hmac_file)
+            if key not in data:
+                sys.exit("A json file with a key named 'secret' was expected "
+                         "for the secret exchange, but wasn't found")
+            hmac_secret = data[key]
+        except ValueError:
+            sys.exit("A JSON was expected for the secret exchange")
+    os.remove(tfile)
+    return hmac_secret
 
-  SetUpLogging( args.log )
 
-  if args.hmac_file_secret:
-    hmac_secret = GetSecretFromTempFile( args.hmac_file_secret )
-    handlers.app.config[ 'jedihttp.hmac_secret' ] = b64decode( hmac_secret )
-    handlers.app.install( HmacPlugin() )
+def main():
+    args = parse_args()
 
-  serve( handlers.app,
-         host = args.host,
-         port = args.port )
+    set_up_logging(args.log)
+
+    if args.hmac_file_secret:
+        hmac_secret = get_secret_from_temp_file(args.hmac_file_secret)
+        handlers.app.config['jedihttp.hmac_secret'] = b64decode(hmac_secret)
+        handlers.app.install(HmacPlugin())
+
+    serve(handlers.app,
+          host=args.host,
+          port=args.port)
+
 
 if __name__ == "__main__":
-  Main()
+    main()

--- a/jedihttp/compatibility.py
+++ b/jedihttp/compatibility.py
@@ -15,58 +15,58 @@
 import sys
 
 if sys.version_info[0] >= 3:
-  basestring = str
-  unicode = str
+    basestring = str
+    unicode = str
 
 
-def encode_string( value ):
-  return value.encode('utf-8') if isinstance(value, unicode) else value
+def encode_string(value):
+    return value.encode('utf-8') if isinstance(value, unicode) else value
 
 
 def decode_string(value):
-  return value if isinstance(value, basestring) else value.decode('utf-8')
+    return value if isinstance(value, basestring) else value.decode('utf-8')
 
 
 # hmac.compare_digest were introduced in python 2.7.7
-if sys.version_info >= ( 2, 7, 7 ):
-  from hmac import compare_digest as SecureStringsEqual
+if sys.version_info >= (2, 7, 7):
+    from hmac import compare_digest as secure_strings_equal
 else:
-  # This is the compare_digest function from python 3.4, adapted for 2.6:
-  # http://hg.python.org/cpython/file/460407f35aa9/Lib/hmac.py#l16
-  #
-  # Stolen from https://github.com/Valloric/ycmd
-  def SecureStringsEqual( a, b ):
-    """Returns the equivalent of 'a == b', but avoids content based short
-    circuiting to reduce the vulnerability to timing attacks."""
-    # Consistent timing matters more here than data type flexibility
-    if not ( isinstance( a, str ) and isinstance( b, str ) ):
-      raise TypeError( "inputs must be str instances" )
+    # This is the compare_digest function from python 3.4, adapted for 2.6:
+    # http://hg.python.org/cpython/file/460407f35aa9/Lib/hmac.py#l16
+    #
+    # Stolen from https://github.com/Valloric/ycmd
+    def secure_strings_equal(a, b):
+        """Returns the equivalent of 'a == b', but avoids content based short
+        circuiting to reduce the vulnerability to timing attacks."""
+        # Consistent timing matters more here than data type flexibility
+        if not (isinstance(a, str) and isinstance(b, str)):
+            raise TypeError("inputs must be str instances")
 
-    # We assume the length of the expected digest is public knowledge,
-    # thus this early return isn't leaking anything an attacker wouldn't
-    # already know
-    if len( a ) != len( b ):
-      return False
+        # We assume the length of the expected digest is public knowledge,
+        # thus this early return isn't leaking anything an attacker wouldn't
+        # already know
+        if len(a) != len(b):
+            return False
 
-    # We assume that integers in the bytes range are all cached,
-    # thus timing shouldn't vary much due to integer object creation
-    result = 0
-    for x, y in zip( a, b ):
-      result |= ord( x ) ^ ord( y )
-    return result == 0
+        # We assume that integers in the bytes range are all cached,
+        # thus timing shouldn't vary much due to integer object creation
+        result = 0
+        for x, y in zip(a, b):
+            result |= ord(x) ^ ord(y)
+        return result == 0
 
 
-def compare_digest( a, b ):
-  return SecureStringsEqual( a, b )
+def compare_digest(a, b):
+    return secure_strings_equal(a, b)
 
 
 try:
-  dict.iteritems
+    dict.iteritems
 except AttributeError:
-  # Python 3
-  def iteritems( dictionary ):
-    return iter( dictionary.items() )
+    # Python 3
+    def iteritems(dictionary):
+        return iter(dictionary.items())
 else:
-  # Python 2
-  def iteritems( dictionary ):
-    return dictionary.iteritems()
+    # Python 2
+    def iteritems(dictionary):
+        return dictionary.iteritems()

--- a/jedihttp/handlers.py
+++ b/jedihttp/handlers.py
@@ -13,7 +13,7 @@
 
 
 from jedihttp import utils
-utils.AddVendorFolderToSysPath()
+utils.add_vendor_folder_to_sys_path()
 
 import contextlib
 import jedi
@@ -27,187 +27,188 @@ from jedihttp.settings import default_settings
 from threading import Lock
 
 try:
-  import httplib
+    import httplib
 except ImportError:
-  from http import client as httplib
+    from http import client as httplib
 
 
 # num bytes for the request body buffer; request.json only works if the request
 # size is less than this
 bottle.Request.MEMFILE_MAX = 1000 * 1024
 
-logger = logging.getLogger( __name__ )
-app = Bottle( __name__ )
+logger = logging.getLogger(__name__)
+app = Bottle(__name__)
 
 # Jedi is not thread safe.
 jedi_lock = Lock()
 
 
-@app.post( '/healthy' )
+@app.post('/healthy')
 def healthy():
-  logger.debug( 'received /healthy request' )
-  return _JsonResponse( True )
+    logger.debug('received /healthy request')
+    return _json_response(True)
 
 
-@app.post( '/ready' )
+@app.post('/ready')
 def ready():
-  logger.debug( 'received /ready request' )
-  return _JsonResponse( True )
+    logger.debug('received /ready request')
+    return _json_response(True)
 
 
-@app.post( '/completions' )
+@app.post('/completions')
 def completions():
-  logger.debug( 'received /completions request' )
-  with jedi_lock:
-    request_json = request.json
-    with _CustomSettings( request_json ):
-      script = _GetJediScript( request_json )
-      response = _FormatCompletions( script.completions() )
-  return _JsonResponse( response )
+    logger.debug('received /completions request')
+    with jedi_lock:
+        request_json = request.json
+        with _custom_settings(request_json):
+            script = _get_jedi_script(request_json)
+            response = _format_completions(script.completions())
+    return _json_response(response)
 
 
-@app.post( '/gotodefinition' )
+@app.post('/gotodefinition')
 def gotodefinition():
-  logger.debug( 'received /gotodefinition request' )
-  with jedi_lock:
-    request_json = request.json
-    with _CustomSettings( request_json ):
-      script = _GetJediScript( request_json )
-      response = _FormatDefinitions( script.goto_definitions() )
-  return _JsonResponse( response )
+    logger.debug('received /gotodefinition request')
+    with jedi_lock:
+        request_json = request.json
+        with _custom_settings(request_json):
+            script = _get_jedi_script(request_json)
+            response = _format_definitions(script.goto_definitions())
+    return _json_response(response)
 
 
-@app.post( '/gotoassignment' )
+@app.post('/gotoassignment')
 def gotoassignments():
-  logger.debug( 'received /gotoassignment request' )
-  with jedi_lock:
-    request_json = request.json
-    follow_imports = request_json.get( 'follow_imports', False )
-    with _CustomSettings( request_json ):
-      script = _GetJediScript( request_json )
-      response = _FormatDefinitions( script.goto_assignments( follow_imports ) )
-  return _JsonResponse( response )
+    logger.debug('received /gotoassignment request')
+    with jedi_lock:
+        request_json = request.json
+        follow_imports = request_json.get('follow_imports', False)
+        with _custom_settings(request_json):
+            script = _get_jedi_script(request_json)
+            response = _format_definitions(
+                script.goto_assignments(follow_imports))
+    return _json_response(response)
 
 
-@app.post( '/usages' )
+@app.post('/usages')
 def usages():
-  logger.debug( 'received /usages request' )
-  with jedi_lock:
-    request_json = request.json
-    with _CustomSettings( request_json ):
-      script = _GetJediScript( request_json )
-      response = _FormatDefinitions( script.usages() )
-  return _JsonResponse( response )
+    logger.debug('received /usages request')
+    with jedi_lock:
+        request_json = request.json
+        with _custom_settings(request_json):
+            script = _get_jedi_script(request_json)
+            response = _format_definitions(script.usages())
+    return _json_response(response)
 
 
-@app.post( '/names' )
+@app.post('/names')
 def names():
-  logger.debug( 'received /names request' )
-  with jedi_lock:
-    request_json = request.json
-    with _CustomSettings( request_json ):
-      definitions = _GetJediNames( request_json )
-      response = _FormatDefinitions( definitions )
-  return _JsonResponse( response )
+    logger.debug('received /names request')
+    with jedi_lock:
+        request_json = request.json
+        with _custom_settings(request_json):
+            definitions = _get_jedi_names(request_json)
+            response = _format_definitions(definitions)
+    return _json_response(response)
 
 
-@app.post( '/preload_module' )
+@app.post('/preload_module')
 def preload_module():
-  logger.debug( 'received /preload_module request' )
-  with jedi_lock:
-    request_json = request.json
-    with _CustomSettings( request_json ):
-      jedi.preload_module( *request_json[ 'modules' ] )
-  return _JsonResponse( True )
+    logger.debug('received /preload_module request')
+    with jedi_lock:
+        request_json = request.json
+        with _custom_settings(request_json):
+            jedi.preload_module(*request_json['modules'])
+    return _json_response(True)
 
 
-def _FormatCompletions( completions ):
-  return {
-      'completions': [ {
-          'module_path': completion.module_path,
-          'name':        completion.name,
-          'type':        completion.type,
-          'line':        completion.line,
-          'column':      completion.column,
-          'docstring':   completion.docstring(),
-          'description': completion.description,
-      } for completion in completions ]
-  }
+def _format_completions(completions):
+    return {
+        'completions': [{
+            'module_path': completion.module_path,
+            'name':        completion.name,
+            'type':        completion.type,
+            'line':        completion.line,
+            'column':      completion.column,
+            'docstring':   completion.docstring(),
+            'description': completion.description,
+        } for completion in completions]
+    }
 
 
-def _FormatDefinitions( definitions ):
-  return {
-      'definitions': [ {
-          'module_path':       definition.module_path,
-          'name':              definition.name,
-          'type':              definition.type,
-          'in_builtin_module': definition.in_builtin_module(),
-          'line':              definition.line,
-          'column':            definition.column,
-          'docstring':         definition.docstring(),
-          'description':       definition.description,
-          'full_name':         definition.full_name,
-          'is_keyword':        definition.is_keyword
-      } for definition in definitions ]
-  }
+def _format_definitions(definitions):
+    return {
+        'definitions': [{
+            'module_path':       definition.module_path,
+            'name':              definition.name,
+            'type':              definition.type,
+            'in_builtin_module': definition.in_builtin_module(),
+            'line':              definition.line,
+            'column':            definition.column,
+            'docstring':         definition.docstring(),
+            'description':       definition.description,
+            'full_name':         definition.full_name,
+            'is_keyword':        definition.is_keyword
+        } for definition in definitions]
+    }
 
 
-def _GetJediScript( request_data ):
-  return jedi.Script( request_data[ 'source' ],
-                      request_data[ 'line' ],
-                      request_data[ 'col' ],
-                      request_data[ 'source_path' ] )
+def _get_jedi_script(request_data):
+    return jedi.Script(request_data['source'],
+                       request_data['line'],
+                       request_data['col'],
+                       request_data['source_path'])
 
 
-def _GetJediNames( request_data ):
-  return jedi.names( source = request_data[ 'source' ],
-                     path = request_data[ 'path' ],
-                     all_scopes = request_data.get( 'all_scopes', False ),
-                     definitions = request_data.get( 'definitions', True ),
-                     references = request_data.get( 'references', False ) )
+def _get_jedi_names(request_data):
+    return jedi.names(source=request_data['source'],
+                      path=request_data['path'],
+                      all_scopes=request_data.get('all_scopes', False),
+                      definitions=request_data.get('definitions', True),
+                      references=request_data.get('references', False))
 
 
-def _SetJediSettings( settings ):
-  for name, value in iteritems( settings ):
-    setattr( jedi.settings, name, value )
+def _set_jedi_settings(settings):
+    for name, value in iteritems(settings):
+        setattr(jedi.settings, name, value)
 
 
 @contextlib.contextmanager
-def _CustomSettings( request_data ):
-  settings = request_data.get( 'settings' )
-  if not settings:
-    yield
-    return
-  try:
-    _SetJediSettings( settings )
-    yield
-  finally:
-    _SetJediSettings( default_settings )
+def _custom_settings(request_data):
+    settings = request_data.get('settings')
+    if not settings:
+        yield
+        return
+    try:
+        _set_jedi_settings(settings)
+        yield
+    finally:
+        _set_jedi_settings(default_settings)
 
 
-@app.error( httplib.INTERNAL_SERVER_ERROR )
-def ErrorHandler( httperror ):
-  body = _JsonResponse( {
-    'exception': httperror.exception,
-    'message': str( httperror.exception ),
-    'traceback': httperror.traceback
-  } )
-  if 'jedihttp.hmac_secret' in app.config:
-    hmac_secret = app.config[ 'jedihttp.hmac_secret' ]
-    hmachelper = hmaclib.JediHTTPHmacHelper( hmac_secret )
-    hmachelper.SignResponseHeaders( response.headers, body )
-  return body
+@app.error(httplib.INTERNAL_SERVER_ERROR)
+def error_handler(httperror):
+    body = _json_response({
+        'exception': httperror.exception,
+        'message': str(httperror.exception),
+        'traceback': httperror.traceback
+    })
+    if 'jedihttp.hmac_secret' in app.config:
+        hmac_secret = app.config['jedihttp.hmac_secret']
+        hmachelper = hmaclib.JediHTTPHmacHelper(hmac_secret)
+        hmachelper.sign_response_headers(response.headers, body)
+    return body
 
 
-def _JsonResponse( data ):
-  response.content_type = 'application/json'
-  return json.dumps( data, default = _Serializer )
+def _json_response(data):
+    response.content_type = 'application/json'
+    return json.dumps(data, default=_serializer)
 
 
-def _Serializer( obj ):
-  try:
-    serialized = obj.__dict__.copy()
-    serialized[ 'TYPE' ] = type( obj ).__name__
-    return serialized
-  except AttributeError:
-    return str( obj )
+def _serializer(obj):
+    try:
+        serialized = obj.__dict__.copy()
+        serialized['TYPE'] = type(obj).__name__
+        return serialized
+    except AttributeError:
+        return str(obj)

--- a/jedihttp/settings.py
+++ b/jedihttp/settings.py
@@ -20,23 +20,30 @@ import sys
 auto_import_modules = jedi.settings.auto_import_modules
 # The socket module uses setattr for several methods (connect, listen, etc.) on
 # Python 2.
-if sys.version_info < ( 3, 0 ):
-  auto_import_modules.append( 'socket' )
+if sys.version_info < (3, 0):
+    auto_import_modules.append('socket')
 
 default_settings = {
-    'case_insensitive_completion'     :
+    'case_insensitive_completion':
         jedi.settings.case_insensitive_completion,
-    'add_bracket_after_function'      :
+    'add_bracket_after_function':
         jedi.settings.add_bracket_after_function,
-    'no_completion_duplicates'        : jedi.settings.no_completion_duplicates,
-    'cache_directory'                 : jedi.settings.cache_directory,
-    'use_filesystem_cache'            : jedi.settings.use_filesystem_cache,
-    'fast_parser'                     : jedi.settings.fast_parser,
-    'dynamic_array_additions'         : jedi.settings.dynamic_array_additions,
-    'dynamic_params'                  : jedi.settings.dynamic_params,
+    'no_completion_duplicates':
+        jedi.settings.no_completion_duplicates,
+    'cache_directory':
+        jedi.settings.cache_directory,
+    'use_filesystem_cache':
+        jedi.settings.use_filesystem_cache,
+    'fast_parser':
+        jedi.settings.fast_parser,
+    'dynamic_array_additions':
+        jedi.settings.dynamic_array_additions,
+    'dynamic_params':
+        jedi.settings.dynamic_params,
     'dynamic_params_for_other_modules':
         jedi.settings.dynamic_params_for_other_modules,
-    'additional_dynamic_modules'      :
+    'additional_dynamic_modules':
         jedi.settings.additional_dynamic_modules,
-    'auto_import_modules'             : auto_import_modules
+    'auto_import_modules':
+        auto_import_modules
 }

--- a/jedihttp/tests/end_to_end_test.py
+++ b/jedihttp/tests/end_to_end_test.py
@@ -21,134 +21,137 @@ from os import path
 from hamcrest import assert_that, equal_to
 
 try:
-  from http import client as httplib
+    from http import client as httplib
 except ImportError:
-  import httplib
+    import httplib
 
-class HmacAuth( requests.auth.AuthBase ):
-  def __init__( self, secret ):
-    self._hmac_helper = hmaclib.JediHTTPHmacHelper( secret )
 
-  def __call__( self, req ):
-    self._hmac_helper.SignRequestHeaders( req.headers,
-                                          req.method,
-                                          req.path_url,
-                                          req.body )
-    return req
+class HmacAuth(requests.auth.AuthBase):
+    def __init__(self, secret):
+        self._hmac_helper = hmaclib.JediHTTPHmacHelper(secret)
+
+    def __call__(self, req):
+        self._hmac_helper.sign_request_headers(req.headers,
+                                               req.method,
+                                               req.path_url,
+                                               req.body)
+        return req
 
 
 PORT = 50000
 SECRET = 'secret'
-PATH_TO_JEDIHTTP = path.abspath( path.join( path.dirname( __file__ ),
-                                            '..', '..', 'jedihttp.py' ) )
+PATH_TO_JEDIHTTP = path.abspath(path.join(path.dirname(__file__),
+                                          '..', '..', 'jedihttp.py'))
 
 
-def wait_for_jedihttp_to_start( jedihttp ):
-  line = jedihttp.stdout.readline().decode( 'utf8' )
-  good_start = line.startswith( 'serving on' )
-  reason = jedihttp.stdout.read().decode( 'utf8' ) if not good_start else ''
-  return good_start, reason
+def wait_for_jedihttp_to_start(jedihttp):
+    line = jedihttp.stdout.readline().decode('utf8')
+    good_start = line.startswith('serving on')
+    reason = jedihttp.stdout.read().decode('utf8') if not good_start else ''
+    return good_start, reason
 
 
 def setup_jedihttp():
-  with hmaclib.TemporaryHmacSecretFile( SECRET ) as hmac_file:
-    command = [ utils.python(),
-                '-u', # this flag makes stdout non buffered
-                PATH_TO_JEDIHTTP,
-                '--port', str( PORT ),
-                '--hmac-file-secret', hmac_file.name ]
-    return utils.SafePopen( command,
-                            stderr = subprocess.STDOUT,
-                            stdout = subprocess.PIPE )
+    with hmaclib.temporary_hmac_secret_file(SECRET) as hmac_file:
+        command = [utils.python(),
+                   '-u',  # this flag makes stdout non buffered
+                   PATH_TO_JEDIHTTP,
+                   '--port', str(PORT),
+                   '--hmac-file-secret', hmac_file.name]
+        return utils.safe_popen(command,
+                                stderr=subprocess.STDOUT,
+                                stdout=subprocess.PIPE)
 
 
-def teardown_jedihttp( jedihttp ):
-  utils.TerminateProcess( jedihttp.pid )
+def teardown_jedihttp(jedihttp):
+    utils.terminate_process(jedihttp.pid)
 
 
-@with_jedihttp( setup_jedihttp, teardown_jedihttp )
-def test_client_request_without_parameters( jedihttp ):
-  good_start, reason = wait_for_jedihttp_to_start( jedihttp )
-  assert_that( good_start, reason )
+@with_jedihttp(setup_jedihttp, teardown_jedihttp)
+def test_client_request_without_parameters(jedihttp):
+    good_start, reason = wait_for_jedihttp_to_start(jedihttp)
+    assert_that(good_start, reason)
 
-  response = requests.post( 'http://127.0.0.1:{0}/ready'.format( PORT ),
-                            auth = HmacAuth( SECRET ) )
+    response = requests.post('http://127.0.0.1:{0}/ready'.format(PORT),
+                             auth=HmacAuth(SECRET))
 
-  assert_that( response.status_code, equal_to( httplib.OK ) )
+    assert_that(response.status_code, equal_to(httplib.OK))
 
-  hmachelper = hmaclib.JediHTTPHmacHelper( SECRET )
-  assert_that( hmachelper.IsResponseAuthenticated( response.headers,
-                                                   response.content ) )
-
-
-@with_jedihttp( setup_jedihttp, teardown_jedihttp )
-def test_client_request_with_parameters( jedihttp ):
-  good_start, reason = wait_for_jedihttp_to_start( jedihttp )
-  assert_that( good_start, reason )
-
-  filepath = utils.fixture_filepath( 'goto.py' )
-  request_data = {
-      'source': read_file( filepath ),
-      'line': 10,
-      'col': 3,
-      'source_path': filepath
-  }
-
-  response = requests.post( 'http://127.0.0.1:{0}/gotodefinition'.format( PORT ),
-                            json = request_data,
-                            auth = HmacAuth( SECRET ) )
-
-  assert_that( response.status_code, equal_to( httplib.OK ) )
-
-  hmachelper = hmaclib.JediHTTPHmacHelper( SECRET )
-  assert_that( hmachelper.IsResponseAuthenticated( response.headers,
-                                                   response.content ) )
+    hmachelper = hmaclib.JediHTTPHmacHelper(SECRET)
+    assert_that(hmachelper.is_response_authenticated(response.headers,
+                                                     response.content))
 
 
-@with_jedihttp( setup_jedihttp, teardown_jedihttp )
-def test_client_bad_request_with_parameters( jedihttp ):
-  good_start, reason = wait_for_jedihttp_to_start( jedihttp )
-  assert_that( good_start, reason )
+@with_jedihttp(setup_jedihttp, teardown_jedihttp)
+def test_client_request_with_parameters(jedihttp):
+    good_start, reason = wait_for_jedihttp_to_start(jedihttp)
+    assert_that(good_start, reason)
 
-  filepath = utils.fixture_filepath( 'goto.py' )
-  request_data = {
-      'source': read_file( filepath ),
-      'line': 100,
-      'col': 1,
-      'source_path': filepath
-  }
+    filepath = utils.fixture_filepath('goto.py')
+    request_data = {
+        'source': read_file(filepath),
+        'line': 10,
+        'col': 3,
+        'source_path': filepath
+    }
 
-  response = requests.post( 'http://127.0.0.1:{0}/gotodefinition'.format( PORT ),
-                            json = request_data,
-                            auth = HmacAuth( SECRET ) )
+    response = requests.post(
+        'http://127.0.0.1:{0}/gotodefinition'.format(PORT),
+        json=request_data,
+        auth=HmacAuth(SECRET))
 
-  assert_that( response.status_code, equal_to( httplib.INTERNAL_SERVER_ERROR ) )
+    assert_that(response.status_code, equal_to(httplib.OK))
 
-  hmachelper = hmaclib.JediHTTPHmacHelper( SECRET )
-  assert_that( hmachelper.IsResponseAuthenticated( response.headers,
-                                                   response.content ) )
+    hmachelper = hmaclib.JediHTTPHmacHelper(SECRET)
+    assert_that(hmachelper.is_response_authenticated(response.headers,
+                                                     response.content))
+
+
+@with_jedihttp(setup_jedihttp, teardown_jedihttp)
+def test_client_bad_request_with_parameters(jedihttp):
+    good_start, reason = wait_for_jedihttp_to_start(jedihttp)
+    assert_that(good_start, reason)
+
+    filepath = utils.fixture_filepath('goto.py')
+    request_data = {
+        'source': read_file(filepath),
+        'line': 100,
+        'col': 1,
+        'source_path': filepath
+    }
+
+    response = requests.post(
+        'http://127.0.0.1:{0}/gotodefinition'.format(PORT),
+        json=request_data,
+        auth=HmacAuth(SECRET))
+
+    assert_that(response.status_code, equal_to(httplib.INTERNAL_SERVER_ERROR))
+
+    hmachelper = hmaclib.JediHTTPHmacHelper(SECRET)
+    assert_that(hmachelper.is_response_authenticated(response.headers,
+                                                     response.content))
 
 
 @py2only
-@with_jedihttp( setup_jedihttp, teardown_jedihttp )
-def test_client_python3_specific_syntax_completion( jedihttp ):
-  good_start, reason = wait_for_jedihttp_to_start( jedihttp )
-  assert_that( good_start, reason )
+@with_jedihttp(setup_jedihttp, teardown_jedihttp)
+def test_client_python3_specific_syntax_completion(jedihttp):
+    good_start, reason = wait_for_jedihttp_to_start(jedihttp)
+    assert_that(good_start, reason)
 
-  filepath = utils.fixture_filepath( 'py3.py' )
-  request_data = {
-      'source': read_file( filepath ),
-      'line': 19,
-      'col': 11,
-      'source_path': filepath
-  }
+    filepath = utils.fixture_filepath('py3.py')
+    request_data = {
+        'source': read_file(filepath),
+        'line': 19,
+        'col': 11,
+        'source_path': filepath
+    }
 
-  response = requests.post( 'http://127.0.0.1:{0}/completions'.format( PORT ),
-                            json = request_data,
-                            auth = HmacAuth( SECRET ) )
+    response = requests.post('http://127.0.0.1:{0}/completions'.format(PORT),
+                             json=request_data,
+                             auth=HmacAuth(SECRET))
 
-  assert_that( response.status_code, equal_to( httplib.OK ) )
+    assert_that(response.status_code, equal_to(httplib.OK))
 
-  hmachelper = hmaclib.JediHTTPHmacHelper( SECRET )
-  assert_that( hmachelper.IsResponseAuthenticated( response.headers,
-                                                   response.content ) )
+    hmachelper = hmaclib.JediHTTPHmacHelper(SECRET)
+    assert_that(hmachelper.is_response_authenticated(response.headers,
+                                                     response.content))

--- a/jedihttp/tests/handlers_test.py
+++ b/jedihttp/tests/handlers_test.py
@@ -18,433 +18,433 @@ from .utils import fixture_filepath, py3only, read_file
 from webtest import TestApp
 from jedihttp import handlers
 from nose.tools import ok_
-from hamcrest import ( assert_that, only_contains, contains, contains_string,
-                       contains_inanyorder, all_of, is_not, has_key, has_item,
-                       has_items, has_entry, has_entries, equal_to, is_, empty )
+from hamcrest import (assert_that, only_contains, contains, contains_string,
+                      contains_inanyorder, all_of, is_not, has_key, has_item,
+                      has_items, has_entry, has_entries, equal_to, is_, empty)
 
 import bottle
-bottle.debug( True )
+bottle.debug(True)
 
 
-def CompletionEntry( name ):
-  return has_entry( 'name', name )
+def completion_entry(name):
+    return has_entry('name', name)
 
 
 def valid_completions():
-  return all_of( has_key( 'docstring' ),
-                 has_key( 'name' ),
-                 has_key( 'description' ) )
+    return all_of(has_key('docstring'),
+                  has_key('name'),
+                  has_key('description'))
 
 
 def test_healthy():
-  app = TestApp( handlers.app )
-  ok_( app.post( '/healthy' ) )
+    app = TestApp(handlers.app)
+    ok_(app.post('/healthy'))
 
 
 def test_ready():
-  app = TestApp( handlers.app )
-  ok_( app.post( '/ready' ) )
+    app = TestApp(handlers.app)
+    ok_(app.post('/ready'))
 
 
 # XXX(vheon): test for unicode, specially for python3
 # where encoding must be specified
 def test_completion():
-  app = TestApp( handlers.app )
-  filepath = fixture_filepath( 'basic.py' )
-  request_data = {
-      'source': read_file( filepath ),
-      'line': 7,
-      'col': 2,
-      'source_path': filepath
-  }
+    app = TestApp(handlers.app)
+    filepath = fixture_filepath('basic.py')
+    request_data = {
+        'source': read_file(filepath),
+        'line': 7,
+        'col': 2,
+        'source_path': filepath
+    }
 
-  completions = app.post_json( '/completions',
-                               request_data ).json[ 'completions' ]
+    completions = app.post_json('/completions',
+                                request_data).json['completions']
 
-  assert_that( completions, only_contains( valid_completions() ) )
-  assert_that( completions, has_items( CompletionEntry( 'a' ),
-                                       CompletionEntry( 'b' ) ) )
+    assert_that(completions, only_contains(valid_completions()))
+    assert_that(completions, has_items(completion_entry('a'),
+                                       completion_entry('b')))
 
 
 def test_good_gotodefinition():
-  app = TestApp( handlers.app )
-  filepath = fixture_filepath( 'goto.py' )
-  request_data = {
-      'source': read_file( filepath ),
-      'line': 10,
-      'col': 3,
-      'source_path': filepath
-  }
+    app = TestApp(handlers.app)
+    filepath = fixture_filepath('goto.py')
+    request_data = {
+        'source': read_file(filepath),
+        'line': 10,
+        'col': 3,
+        'source_path': filepath
+    }
 
-  definitions = app.post_json( '/gotodefinition',
-                               request_data ).json[ 'definitions' ]
+    definitions = app.post_json('/gotodefinition',
+                                request_data).json['definitions']
 
-  assert_that( definitions, contains_inanyorder(
-      {
-          'module_path': filepath,
-          'name': 'f',
-          'type': 'function',
-          'in_builtin_module': False,
-          'line': 1,
-          'column': 4,
-          'docstring': 'f()\n\nModule method docs\nAre '
-                       'dedented, like you might expect',
-          'description': 'def f',
-          'full_name': 'goto.f',
-          'is_keyword': False,
-      },
-      {
-          'module_path': filepath,
-          'name': 'C',
-          'type': 'class',
-          'in_builtin_module': False,
-          'line': 6,
-          'column': 6,
-          'docstring': 'Class Documentation',
-          'description': 'class C',
-          'full_name': 'goto.C',
-          'is_keyword': False
-      }
-  ) )
+    assert_that(definitions, contains_inanyorder(
+        {
+            'module_path': filepath,
+            'name': 'f',
+            'type': 'function',
+            'in_builtin_module': False,
+            'line': 1,
+            'column': 4,
+            'docstring': 'f()\n\nModule method docs\nAre '
+                         'dedented, like you might expect',
+            'description': 'def f',
+            'full_name': 'goto.f',
+            'is_keyword': False,
+        },
+        {
+            'module_path': filepath,
+            'name': 'C',
+            'type': 'class',
+            'in_builtin_module': False,
+            'line': 6,
+            'column': 6,
+            'docstring': 'Class Documentation',
+            'description': 'class C',
+            'full_name': 'goto.C',
+            'is_keyword': False
+        }
+    ))
 
 
 def test_bad_gotodefinitions_blank_line():
-  app = TestApp( handlers.app )
-  filepath = fixture_filepath( 'goto.py' )
-  request_data = {
-      'source': read_file( filepath ),
-      'line': 9,
-      'col': 1,
-      'source_path': filepath
-  }
-  definitions = app.post_json( '/gotodefinition',
-                               request_data ).json[ 'definitions' ]
-  assert_that( definitions, is_( empty() ) )
+    app = TestApp(handlers.app)
+    filepath = fixture_filepath('goto.py')
+    request_data = {
+        'source': read_file(filepath),
+        'line': 9,
+        'col': 1,
+        'source_path': filepath
+    }
+    definitions = app.post_json('/gotodefinition',
+                                request_data).json['definitions']
+    assert_that(definitions, is_(empty()))
 
 
 def test_bad_gotodefinitions_not_on_valid_position():
-  app = TestApp( handlers.app )
-  filepath = fixture_filepath( 'goto.py' )
-  request_data = {
-      'source': read_file( filepath ),
-      'line': 100,
-      'col': 1,
-      'source_path': filepath
-  }
-  response = app.post_json( '/gotodefinition',
-                            request_data,
-                            expect_errors = True )
-  assert_that( response.status_int, equal_to( 500 ) )
+    app = TestApp(handlers.app)
+    filepath = fixture_filepath('goto.py')
+    request_data = {
+        'source': read_file(filepath),
+        'line': 100,
+        'col': 1,
+        'source_path': filepath
+    }
+    response = app.post_json('/gotodefinition',
+                             request_data,
+                             expect_errors=True)
+    assert_that(response.status_int, equal_to(500))
 
 
 def test_good_gotoassignment():
-  app = TestApp( handlers.app )
-  filepath = fixture_filepath( 'goto.py' )
-  request_data = {
-      'source': read_file( filepath ),
-      'line': 20,
-      'col': 1,
-      'source_path': filepath
-  }
+    app = TestApp(handlers.app)
+    filepath = fixture_filepath('goto.py')
+    request_data = {
+        'source': read_file(filepath),
+        'line': 20,
+        'col': 1,
+        'source_path': filepath
+    }
 
-  definitions = app.post_json( '/gotoassignment',
-                               request_data ).json[ 'definitions' ]
+    definitions = app.post_json('/gotoassignment',
+                                request_data).json['definitions']
 
-  assert_that( definitions, contains( {
-      'module_path': filepath,
-      'name': 'inception',
-      'type': 'statement',
-      'in_builtin_module': False,
-      'line': 18,
-      'column': 0,
-      'docstring': '',
-      'description': 'inception = _list[ 2 ]',
-      'full_name': 'goto.inception',
-      'is_keyword': False
-  } ) )
+    assert_that(definitions, contains({
+        'module_path': filepath,
+        'name': 'inception',
+        'type': 'statement',
+        'in_builtin_module': False,
+        'line': 18,
+        'column': 0,
+        'docstring': '',
+        'description': 'inception = _list[ 2 ]',
+        'full_name': 'goto.inception',
+        'is_keyword': False
+    }))
 
 
 def test_good_gotoassignment_do_not_follow_imports():
-  app = TestApp( handlers.app )
-  filepath = fixture_filepath( 'follow_imports', 'importer.py' )
-  request_data = {
-      'source': read_file( filepath ),
-      'line': 3,
-      'col': 9,
-      'source_path': filepath
-  }
-  expected_definition = {
-      'module_path': filepath,
-      'name': 'imported_function',
-      'type': 'function',
-      'in_builtin_module': False,
-      'line': 1,
-      'column': 21,
-      'docstring': 'imported_function()\n\n',
-      'description': 'def imported_function',
-      'full_name': 'imported.imported_function',
-      'is_keyword': False
-  }
+    app = TestApp(handlers.app)
+    filepath = fixture_filepath('follow_imports', 'importer.py')
+    request_data = {
+        'source': read_file(filepath),
+        'line': 3,
+        'col': 9,
+        'source_path': filepath
+    }
+    expected_definition = {
+        'module_path': filepath,
+        'name': 'imported_function',
+        'type': 'function',
+        'in_builtin_module': False,
+        'line': 1,
+        'column': 21,
+        'docstring': 'imported_function()\n\n',
+        'description': 'def imported_function',
+        'full_name': 'imported.imported_function',
+        'is_keyword': False
+    }
 
-  definitions = app.post_json( '/gotoassignment',
-                               request_data ).json[ 'definitions' ]
+    definitions = app.post_json('/gotoassignment',
+                                request_data).json['definitions']
 
-  assert_that( definitions, contains( expected_definition ) )
+    assert_that(definitions, contains(expected_definition))
 
-  request_data[ 'follow_imports' ] = False
+    request_data['follow_imports'] = False
 
-  definitions = app.post_json( '/gotoassignment',
-                               request_data ).json[ 'definitions' ]
+    definitions = app.post_json('/gotoassignment',
+                                request_data).json['definitions']
 
-  assert_that( definitions, contains( expected_definition ) )
+    assert_that(definitions, contains(expected_definition))
 
 
 def test_good_gotoassignment_follow_imports():
-  app = TestApp( handlers.app )
-  importer_filepath = fixture_filepath( 'follow_imports', 'importer.py' )
-  imported_filepath = fixture_filepath( 'follow_imports', 'imported.py' )
-  request_data = {
-      'source': read_file( importer_filepath ),
-      'line': 3,
-      'col': 9,
-      'source_path': importer_filepath,
-      'follow_imports': True
-  }
+    app = TestApp(handlers.app)
+    importer_filepath = fixture_filepath('follow_imports', 'importer.py')
+    imported_filepath = fixture_filepath('follow_imports', 'imported.py')
+    request_data = {
+        'source': read_file(importer_filepath),
+        'line': 3,
+        'col': 9,
+        'source_path': importer_filepath,
+        'follow_imports': True
+    }
 
-  definitions = app.post_json( '/gotoassignment',
-                               request_data ).json[ 'definitions' ]
+    definitions = app.post_json('/gotoassignment',
+                                request_data).json['definitions']
 
-  assert_that( definitions, contains( {
-      'module_path': imported_filepath,
-      'name': 'imported_function',
-      'type': 'function',
-      'in_builtin_module': False,
-      'line': 1,
-      'column': 4,
-      'docstring': 'imported_function()\n\n',
-      'description': 'def imported_function',
-      'full_name': 'imported.imported_function',
-      'is_keyword': False
-  } ) )
+    assert_that(definitions, contains({
+        'module_path': imported_filepath,
+        'name': 'imported_function',
+        'type': 'function',
+        'in_builtin_module': False,
+        'line': 1,
+        'column': 4,
+        'docstring': 'imported_function()\n\n',
+        'description': 'def imported_function',
+        'full_name': 'imported.imported_function',
+        'is_keyword': False
+    }))
 
 
 def test_usages():
-  app = TestApp( handlers.app )
-  filepath = fixture_filepath( 'usages.py' )
-  request_data = {
-      'source': read_file( filepath ),
-      'line': 8,
-      'col': 5,
-      'source_path': filepath
-  }
+    app = TestApp(handlers.app)
+    filepath = fixture_filepath('usages.py')
+    request_data = {
+        'source': read_file(filepath),
+        'line': 8,
+        'col': 5,
+        'source_path': filepath
+    }
 
-  definitions = app.post_json( '/usages',
-                               request_data ).json[ 'definitions' ]
+    definitions = app.post_json('/usages',
+                                request_data).json['definitions']
 
-  assert_that( definitions, contains_inanyorder(
-      {
-          'module_path': filepath,
-          'name': 'f',
-          'type': 'function',
-          'in_builtin_module': False,
-          'line': 1,
-          'column': 4,
-          'docstring': 'f()\n\nModule method docs\n'
-                       'Are dedented, like you might expect',
-          'description': 'def f',
-          'full_name': 'usages.f',
-          'is_keyword': False
-      },
-      {
-          'module_path': filepath,
-          'name': 'f',
-          'type': 'statement',
-          'in_builtin_module': False,
-          'line': 6,
-          'column': 4,
-          'description': 'a = f()',
-          'docstring': '',
-          'full_name': 'usages.f',
-          'is_keyword': False
-      },
-      {
-          'module_path': filepath,
-          'name': 'f',
-          'type': 'statement',
-          'in_builtin_module': False,
-          'line': 7,
-          'column': 4,
-          'description': 'b = f()',
-          'docstring': '',
-          'full_name': 'usages.f',
-          'is_keyword': False
-      },
-      {
-          'module_path': filepath,
-          'name': 'f',
-          'type': 'statement',
-          'in_builtin_module': False,
-          'line': 8,
-          'column': 4,
-          'description': 'c = f()',
-          'docstring': '',
-          'full_name': 'usages.f',
-          'is_keyword': False
-      }
-  ) )
+    assert_that(definitions, contains_inanyorder(
+        {
+            'module_path': filepath,
+            'name': 'f',
+            'type': 'function',
+            'in_builtin_module': False,
+            'line': 1,
+            'column': 4,
+            'docstring': 'f()\n\nModule method docs\n'
+                         'Are dedented, like you might expect',
+            'description': 'def f',
+            'full_name': 'usages.f',
+            'is_keyword': False
+        },
+        {
+            'module_path': filepath,
+            'name': 'f',
+            'type': 'statement',
+            'in_builtin_module': False,
+            'line': 6,
+            'column': 4,
+            'description': 'a = f()',
+            'docstring': '',
+            'full_name': 'usages.f',
+            'is_keyword': False
+        },
+        {
+            'module_path': filepath,
+            'name': 'f',
+            'type': 'statement',
+            'in_builtin_module': False,
+            'line': 7,
+            'column': 4,
+            'description': 'b = f()',
+            'docstring': '',
+            'full_name': 'usages.f',
+            'is_keyword': False
+        },
+        {
+            'module_path': filepath,
+            'name': 'f',
+            'type': 'statement',
+            'in_builtin_module': False,
+            'line': 8,
+            'column': 4,
+            'description': 'c = f()',
+            'docstring': '',
+            'full_name': 'usages.f',
+            'is_keyword': False
+        }
+    ))
 
 
 def test_names():
-  app = TestApp( handlers.app )
-  filepath = fixture_filepath( 'names.py' )
-  request_data = {
-      'source': read_file( filepath ),
-      'path': filepath,
-      'all_scopes': False,
-      'definitions': True,
-      'references': False
-  }
+    app = TestApp(handlers.app)
+    filepath = fixture_filepath('names.py')
+    request_data = {
+        'source': read_file(filepath),
+        'path': filepath,
+        'all_scopes': False,
+        'definitions': True,
+        'references': False
+    }
 
-  definitions = app.post_json( '/names', request_data ).json[ 'definitions' ]
+    definitions = app.post_json('/names', request_data).json['definitions']
 
-  assert_that( definitions, contains_inanyorder(
-      has_entries( {
-        'module_path': filepath,
-        'name': 'os',
-        'type': 'module',
-        'in_builtin_module': False,
-        'line': 1,
-        'column': 7,
-        'docstring': contains_string( 'OS routines' ),
-        'description': 'module os',
-        'full_name': 'os',
-        'is_keyword': False
-      } ),
-      has_entries( {
-        'module_path': filepath,
-        'name': 'CONSTANT',
-        'type': 'statement',
-        'in_builtin_module': False,
-        'line': 3,
-        'column': 0,
-        'docstring': '',
-        'description': 'CONSTANT = 1',
-        'full_name': 'names.CONSTANT',
-        'is_keyword': False
-      } ),
-      has_entries( {
-        'module_path': filepath,
-        'name': 'test',
-        'type': 'function',
-        'in_builtin_module': False,
-        'line': 5,
-        'column': 4,
-        'docstring': 'test()\n\n',
-        'description': 'def test',
-        'full_name': 'names.test',
-        'is_keyword': False
-      } )
-  ) )
+    assert_that(definitions, contains_inanyorder(
+        has_entries({
+            'module_path': filepath,
+            'name': 'os',
+            'type': 'module',
+            'in_builtin_module': False,
+            'line': 1,
+            'column': 7,
+            'docstring': contains_string('OS routines'),
+            'description': 'module os',
+            'full_name': 'os',
+            'is_keyword': False
+        }),
+        has_entries({
+            'module_path': filepath,
+            'name': 'CONSTANT',
+            'type': 'statement',
+            'in_builtin_module': False,
+            'line': 3,
+            'column': 0,
+            'docstring': '',
+            'description': 'CONSTANT = 1',
+            'full_name': 'names.CONSTANT',
+            'is_keyword': False
+        }),
+        has_entries({
+            'module_path': filepath,
+            'name': 'test',
+            'type': 'function',
+            'in_builtin_module': False,
+            'line': 5,
+            'column': 4,
+            'docstring': 'test()\n\n',
+            'description': 'def test',
+            'full_name': 'names.test',
+            'is_keyword': False
+        })
+    ))
 
 
 def test_preload_module():
-  app = TestApp( handlers.app )
-  request_data = {
-      'modules': [ 'os', 'sys' ]
-  }
+    app = TestApp(handlers.app)
+    request_data = {
+        'modules': ['os', 'sys']
+    }
 
-  ok_( app.post_json( '/preload_module', request_data ) )
+    ok_(app.post_json('/preload_module', request_data))
 
 
 def test_usages_settings_additional_dynamic_modules():
-  app = TestApp( handlers.app )
-  file1 = fixture_filepath( 'module', 'some_module', 'file1.py' )
-  file2 = fixture_filepath( 'module', 'some_module', 'file2.py' )
-  main_file = fixture_filepath( 'module', 'main.py' )
-  request_data = {
-      'source': read_file( file2 ),
-      'line': 5,
-      'col': 17,
-      'source_path': file2,
-      'settings': {
-          'additional_dynamic_modules': [ main_file ]
-      }
-  }
+    app = TestApp(handlers.app)
+    file1 = fixture_filepath('module', 'some_module', 'file1.py')
+    file2 = fixture_filepath('module', 'some_module', 'file2.py')
+    main_file = fixture_filepath('module', 'main.py')
+    request_data = {
+        'source': read_file(file2),
+        'line': 5,
+        'col': 17,
+        'source_path': file2,
+        'settings': {
+            'additional_dynamic_modules': [main_file]
+        }
+    }
 
-  definitions = app.post_json( '/usages',
-                               request_data ).json[ 'definitions' ]
+    definitions = app.post_json('/usages',
+                                request_data).json['definitions']
 
-  assert_that( definitions, contains_inanyorder(
-      has_entries( {
-          'module_path': file2,
-          'name': 'FILE1_CONSTANT',
-          'line': 5,
-          'column': 11
-      } ),
-      has_entries( {
-          'module_path': file2,
-          'name': 'FILE1_CONSTANT',
-          'line': 1,
-          'column': 18
-      } ),
-      has_entries( {
-          'module_path': file1,
-          'name': 'FILE1_CONSTANT',
-          'line': 5,
-          'column': 11
-      } ),
-      has_entries( {
-          'module_path': file1,
-          'name': 'FILE1_CONSTANT',
-          'line': 1,
-          'column': 0
-      } ),
-      has_entries( {
-          'module_path': main_file,
-          'name': 'FILE1_CONSTANT',
-          'line': 1,
-          'column': 30
-      } ),
-      has_entries( {
-          'module_path': main_file,
-          'name': 'FILE1_CONSTANT',
-          'line': 5,
-          'column': 11
-      } )
-  ) )
+    assert_that(definitions, contains_inanyorder(
+        has_entries({
+            'module_path': file2,
+            'name': 'FILE1_CONSTANT',
+            'line': 5,
+            'column': 11
+        }),
+        has_entries({
+            'module_path': file2,
+            'name': 'FILE1_CONSTANT',
+            'line': 1,
+            'column': 18
+        }),
+        has_entries({
+            'module_path': file1,
+            'name': 'FILE1_CONSTANT',
+            'line': 5,
+            'column': 11
+        }),
+        has_entries({
+            'module_path': file1,
+            'name': 'FILE1_CONSTANT',
+            'line': 1,
+            'column': 0
+        }),
+        has_entries({
+            'module_path': main_file,
+            'name': 'FILE1_CONSTANT',
+            'line': 1,
+            'column': 30
+        }),
+        has_entries({
+            'module_path': main_file,
+            'name': 'FILE1_CONSTANT',
+            'line': 5,
+            'column': 11
+        })
+    ))
 
 
 @py3only
 def test_py3():
-  app = TestApp( handlers.app )
-  filepath = fixture_filepath( 'py3.py' )
-  request_data = {
-      'source': read_file( filepath ),
-      'line': 19,
-      'col': 11,
-      'source_path': filepath
-  }
+    app = TestApp(handlers.app)
+    filepath = fixture_filepath('py3.py')
+    request_data = {
+        'source': read_file(filepath),
+        'line': 19,
+        'col': 11,
+        'source_path': filepath
+    }
 
-  completions = app.post_json( '/completions',
-                                request_data ).json[ 'completions' ]
+    completions = app.post_json('/completions',
+                                request_data).json['completions']
 
-  assert_that( completions, has_item( CompletionEntry( 'values' ) ) )
-  assert_that( completions,
-               is_not( has_item( CompletionEntry( 'itervalues' ) ) ) )
+    assert_that(completions, has_item(completion_entry('values')))
+    assert_that(completions,
+                is_not(has_item(completion_entry('itervalues'))))
 
 
 def test_completion_socket_module():
-  app = TestApp( handlers.app )
-  filepath = fixture_filepath( 'socket_module.py' )
-  request_data = {
-      'source': read_file( filepath ),
-      'line': 4,
-      'col': 4,
-      'source_path': filepath
-  }
+    app = TestApp(handlers.app)
+    filepath = fixture_filepath('socket_module.py')
+    request_data = {
+        'source': read_file(filepath),
+        'line': 4,
+        'col': 4,
+        'source_path': filepath
+    }
 
-  completions = app.post_json( '/completions',
-                                request_data ).json[ 'completions' ]
+    completions = app.post_json('/completions',
+                                request_data).json['completions']
 
-  assert_that( completions, has_items( CompletionEntry( 'connect' ),
-                                       CompletionEntry( 'connect_ex' ) ) )
+    assert_that(completions, has_items(completion_entry('connect'),
+                                       completion_entry('connect_ex')))

--- a/jedihttp/utils.py
+++ b/jedihttp/utils.py
@@ -15,9 +15,9 @@ import os
 import sys
 
 
-def AddVendorFolderToSysPath():
-  vendor_folder = os.path.join( os.path.dirname( __file__ ), '..', 'vendor' )
+def add_vendor_folder_to_sys_path():
+    vendor_folder = os.path.join(os.path.dirname(__file__), '..', 'vendor')
 
-  for folder in os.listdir( vendor_folder ):
-    sys.path.insert( 0, os.path.realpath( os.path.join( vendor_folder,
-                                                        folder ) ) )
+    for folder in os.listdir(vendor_folder):
+        sys.path.insert(0, os.path.realpath(os.path.join(vendor_folder,
+                                                         folder)))

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,7 @@
-flake8     >= 2.0
-nose       >= 1.3.0
+flake8      >= 2.0
+pep8-naming >= 0.4.1
+nose        >= 1.3.0
 # WebTest 2.0.24 dropped support of Python 2.6
-WebTest    >= 2.0.0, < 2.0.24
-PyHamcrest >= 1.8.0
-requests   >= 2.8.1
+WebTest     >= 2.0.0, < 2.0.24
+PyHamcrest  >= 1.8.0
+requests    >= 2.8.1

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,25 @@ skipsdist = True
 [testenv]
 deps = -r{toxinidir}/test_requirements.txt
 commands =
-  nosetests -v
+    nosetests -v {posargs}
 [testenv:py26]
 deps =
     {[testenv]deps}
     unittest2
     ordereddict
-[testenv:flake8]
+[testenv:py27-flake8]
 deps = {[testenv]deps}
 commands =
-  flake8 --select=F,C9 --max-complexity=10 --exclude=fixtures jedihttp
+    flake8
+[testenv:py36-flake8]
+deps = {[testenv]deps}
+commands =
+    flake8
+[flake8]
+ignore = E241,E402
+max_complexity = 10
+exclude =
+    .git,
+    .tox,
+    fixtures,
+    vendor


### PR DESCRIPTION
Following [PEP8 code style](https://www.python.org/dev/peps/pep-0008/) requires some changes in `test_requirements.txt` and `tox.ini`:
 - add `pep8-naming` package to follow [PEP8 naming conventions](https://www.python.org/dev/peps/pep-0008/#naming-conventions);
 - add flake8 configuration to `tox.ini`: [only ignore E203 and E402](https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes). Adding whitespaces before `:` improves readability when defining dictionaries and moving all imports at the top of file is not possible because of packages bundling;
 - fix flake8 runs on Travis and AppVeyor (`py27-flake8` and `py36-flake8` through the `tox -e` command were running the tests instead of flake8).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vheon/jedihttp/38)
<!-- Reviewable:end -->
