### PR TITLE
[READY] Add shutdown handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,16 @@ Response:
 true
 ```
 
+### POST /shutdown
+
+Shut down the server.
+
+Response:
+
+```javascript
+true
+```
+
 ### In case of errors
 
 Response:

--- a/jedihttp.py
+++ b/jedihttp.py
@@ -20,9 +20,9 @@ import os
 import sys
 from base64 import b64decode
 from argparse import ArgumentParser
-from waitress import serve
 from jedihttp import handlers
 from jedihttp.hmac_plugin import HmacPlugin
+from jedihttp.wsgi_server import StoppableWSGIServer
 
 
 def parse_args():
@@ -75,9 +75,10 @@ def main():
         handlers.app.config['jedihttp.hmac_secret'] = b64decode(hmac_secret)
         handlers.app.install(HmacPlugin())
 
-    serve(handlers.app,
-          host=args.host,
-          port=args.port)
+    handlers.wsgi_server = StoppableWSGIServer(handlers.app,
+                                               host=args.host,
+                                               port=args.port)
+    handlers.wsgi_server.start()
 
 
 if __name__ == "__main__":

--- a/jedihttp/compatibility.py
+++ b/jedihttp/compatibility.py
@@ -64,9 +64,15 @@ try:
     dict.iteritems
 except AttributeError:
     # Python 3
+    def listvalues(dictionary):
+        return list(dictionary.values())
+
     def iteritems(dictionary):
         return iter(dictionary.items())
 else:
     # Python 2
+    def listvalues(dictionary):
+        return dictionary.values()
+
     def iteritems(dictionary):
         return dictionary.iteritems()

--- a/jedihttp/hmaclib.py
+++ b/jedihttp/hmaclib.py
@@ -24,18 +24,18 @@ def temporary_hmac_secret_file(secret):
     """Helper function for passing the hmac secret when starting a JediHTTP
     server:
 
-      with temporary_hmac_secret_file('mysecret') as hmac_file:
-          jedihttp = subprocess.Popen(['python',
-                                       'jedihttp',
-                                       '--hmac-file-secret', hmac_file.name])
+      hmac_file = temporary_hmac_secret_file('mysecret')
+      jedihttp = subprocess.Popen(['python',
+                                   'jedihttp',
+                                   '--hmac-file-secret', hmac_file])
 
     The JediHTTP Server as soon as it reads the hmac secret will remove the
     file.
     """
-    hmac_file = tempfile.NamedTemporaryFile('w', delete=False)
     encoded_secret = decode_string(b64encode(encode_string(secret)))
-    json.dump({'hmac_secret': encoded_secret}, hmac_file)
-    return hmac_file
+    with tempfile.NamedTemporaryFile('w', delete=False) as hmac_file:
+        json.dump({'hmac_secret': encoded_secret}, hmac_file)
+    return hmac_file.name
 
 
 _HMAC_HEADER = 'x-jedihttp-hmac'

--- a/jedihttp/tests/end_to_end_test.py
+++ b/jedihttp/tests/end_to_end_test.py
@@ -12,11 +12,15 @@
 #    limitations under the License.
 
 
-from . import utils
-from .utils import with_jedihttp, py2only, read_file
 import requests
 import subprocess
+import sys
+import time
 from jedihttp import hmaclib
+from jedihttp.compatibility import decode_string
+from jedihttp.tests import utils
+from jedihttp.tests.utils import (process_is_running, py2only, read_file,
+                                  wait_process_shutdown, with_jedihttp)
 from os import path
 from hamcrest import assert_that, equal_to
 
@@ -44,34 +48,53 @@ PATH_TO_JEDIHTTP = path.abspath(path.join(path.dirname(__file__),
                                           '..', '..', 'jedihttp.py'))
 
 
-def wait_for_jedihttp_to_start(jedihttp):
-    line = jedihttp.stdout.readline().decode('utf8')
-    good_start = line.startswith('serving on')
-    reason = jedihttp.stdout.read().decode('utf8') if not good_start else ''
-    return good_start, reason
+def wait_until_jedihttp_ready(timeout=5):
+    expiration = time.time() + timeout
+    while True:
+        if time.time() > expiration:
+            raise RuntimeError('Waited for JediHTTP to be ready '
+                               'for {0} seconds, aborting.'.format(timeout))
+
+        try:
+            if requests.post('http://127.0.0.1:{0}/ready'.format(PORT),
+                             auth=HmacAuth(SECRET)).json():
+                return
+        except requests.exceptions.ConnectionError:
+            time.sleep(0.1)
 
 
 def setup_jedihttp():
-    with hmaclib.temporary_hmac_secret_file(SECRET) as hmac_file:
-        command = [utils.python(),
-                   '-u',  # this flag makes stdout non buffered
-                   PATH_TO_JEDIHTTP,
-                   '--port', str(PORT),
-                   '--hmac-file-secret', hmac_file.name]
-        return utils.safe_popen(command,
-                                stderr=subprocess.STDOUT,
-                                stdout=subprocess.PIPE)
+    hmac_file = hmaclib.temporary_hmac_secret_file(SECRET)
+    command = [utils.python(),
+               PATH_TO_JEDIHTTP,
+               '--port', str(PORT),
+               '--log', 'debug',
+               '--hmac-file-secret', hmac_file]
+    jedihttp = utils.safe_popen(command,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT)
+    wait_until_jedihttp_ready()
+    return jedihttp
 
 
 def teardown_jedihttp(jedihttp):
-    utils.terminate_process(jedihttp.pid)
+    try:
+        requests.post('http://127.0.0.1:{0}/shutdown'.format(PORT),
+                      auth=HmacAuth(SECRET))
+    except requests.exceptions.ConnectionError:
+        pass
+
+    try:
+        wait_process_shutdown(jedihttp)
+    except RuntimeError:
+        jedihttp.terminate()
+
+    stdout, _ = jedihttp.communicate()
+    sys.stdout.write(decode_string(stdout))
 
 
 @with_jedihttp(setup_jedihttp, teardown_jedihttp)
 def test_client_request_without_parameters(jedihttp):
-    good_start, reason = wait_for_jedihttp_to_start(jedihttp)
-    assert_that(good_start, reason)
-
     response = requests.post('http://127.0.0.1:{0}/ready'.format(PORT),
                              auth=HmacAuth(SECRET))
 
@@ -84,9 +107,6 @@ def test_client_request_without_parameters(jedihttp):
 
 @with_jedihttp(setup_jedihttp, teardown_jedihttp)
 def test_client_request_with_parameters(jedihttp):
-    good_start, reason = wait_for_jedihttp_to_start(jedihttp)
-    assert_that(good_start, reason)
-
     filepath = utils.fixture_filepath('goto.py')
     request_data = {
         'source': read_file(filepath),
@@ -109,9 +129,6 @@ def test_client_request_with_parameters(jedihttp):
 
 @with_jedihttp(setup_jedihttp, teardown_jedihttp)
 def test_client_bad_request_with_parameters(jedihttp):
-    good_start, reason = wait_for_jedihttp_to_start(jedihttp)
-    assert_that(good_start, reason)
-
     filepath = utils.fixture_filepath('goto.py')
     request_data = {
         'source': read_file(filepath),
@@ -135,9 +152,6 @@ def test_client_bad_request_with_parameters(jedihttp):
 @py2only
 @with_jedihttp(setup_jedihttp, teardown_jedihttp)
 def test_client_python3_specific_syntax_completion(jedihttp):
-    good_start, reason = wait_for_jedihttp_to_start(jedihttp)
-    assert_that(good_start, reason)
-
     filepath = utils.fixture_filepath('py3.py')
     request_data = {
         'source': read_file(filepath),
@@ -155,3 +169,19 @@ def test_client_python3_specific_syntax_completion(jedihttp):
     hmachelper = hmaclib.JediHTTPHmacHelper(SECRET)
     assert_that(hmachelper.is_response_authenticated(response.headers,
                                                      response.content))
+
+
+@with_jedihttp(setup_jedihttp, teardown_jedihttp)
+def test_client_shutdown(jedihttp):
+    response = requests.post('http://127.0.0.1:{0}/shutdown'.format(PORT),
+                             auth=HmacAuth(SECRET))
+
+    assert_that(response.status_code, equal_to(httplib.OK))
+    assert_that(response.json(), equal_to(True))
+
+    hmachelper = hmaclib.JediHTTPHmacHelper(SECRET)
+    assert_that(hmachelper.is_response_authenticated(response.headers,
+                                                     response.content))
+
+    wait_process_shutdown(jedihttp)
+    assert_that(process_is_running(jedihttp), equal_to(False))

--- a/jedihttp/wsgi_server.py
+++ b/jedihttp/wsgi_server.py
@@ -1,0 +1,53 @@
+#     Copyright 2017 Cedraro Andrea <a.cedraro@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from jedihttp.compatibility import listvalues
+from waitress.server import TcpWSGIServer
+import select
+
+
+class StoppableWSGIServer(TcpWSGIServer):
+    """StoppableWSGIServer is a subclass of the TcpWSGIServer Waitress server
+    with a shutdown method. It is based on StopableWSGIServer class from
+    webtest: https://github.com/Pylons/webtest/blob/master/webtest/http.py"""
+
+    shutdown_requested = False
+
+    def start(self):
+        """Wrapper of TcpWSGIServer run method. It prevents a traceback from
+        asyncore."""
+
+        # Message for compatibility with clients who expect the output from
+        # waitress.serve here.
+        print('serving on http://{0}:{1}'.format(self.effective_host,
+                                                 self.effective_port))
+
+        try:
+            self.run()
+        except select.error:
+            if not self.shutdown_requested:
+                raise
+
+    def shutdown(self):
+        """Properly shut down the server."""
+        self.shutdown_requested = True
+        # Shut down waitress threads.
+        self.task_dispatcher.shutdown()
+        # Close asyncore channels.
+        # We can't use an iterator here because _map is modified while looping
+        # through it.
+        # NOTE: _map is an attribute from the asyncore.dispatcher class, which
+        # is a base class of TcpWSGIServer. This may change in future versions
+        # of waitress so extra care should be taken when updating waitress.
+        for channel in listvalues(self._map):
+            channel.close()


### PR DESCRIPTION
Adding a `shutdown` endpoint makes it possible to cleanly exit JediHTTP on Windows. This is implemented the same way as in ycmd. See PR https://github.com/Valloric/ycmd/pull/282 for more detail.

I made the following changes to the setup and teardown methods of the end-to-end tests:
 - start the server with logging level set to `debug`;
 - wait for the server to be ready before each test;
 - use the new `shutdown` handler to stop the server after each test;
 - write the output of the server to nosetests stdout at the end of each test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vheon/jedihttp/39)
<!-- Reviewable:end -->
