### PR TITLE
[READY] Fix nose --ignore-files option

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,9 @@ commands =
                f.write('import coverage\ncoverage.process_startup()')"
     # nose ignores __main__.py by default but we want to cover this file. Only
     # ignore files whose name starts with a dot.
-    nosetests -v --ignore-files=^\.$ --with-coverage --cover-erase \
-              --cover-package=jedihttp --cover-html --cover-inclusive {posargs}
+    nosetests -v --ignore-files=(^\.|^setup\.py$) --with-coverage \
+              --cover-erase --cover-package=jedihttp --cover-html \
+              --cover-inclusive {posargs}
 [testenv:py26]
 deps =
     {[testenv]deps}


### PR DESCRIPTION
We were only ignoring the file `.` instead of all files starting with a dot when running the tests. With this PR, we also ignore the `setup.py` file since:
 - it's ignored by default (the default being `(^\.|^_|^setup\.py$)`);
 - should make the life of maintainers easier (see [the Arch Linux JediHTTP package](https://aur.archlinux.org/cgit/aur.git/tree/?h=python-jedihttp-git) for instance);
 - we may consider adding this file in the future.

Thanks to @yan12125.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vheon/jedihttp/42)
<!-- Reviewable:end -->
