### PR TITLE
config for python project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .tox/
 .coverage
 cover/
+*.swp

--- a/README.md
+++ b/README.md
@@ -359,6 +359,17 @@ Assuming `||` stands for concatenation:
 
 I'm not a python programmer but I'm using this to experiment with python a bit.
 
+## Configuration
+
+### python config
+
+#### add your project path to python's sys.path for JediHttp
+
+1. add vimrc.py in your/project/root/directory
+2. define fucticon onStartJediyhttp in vimrc.py, like example/vimrc.py
+3. @onStartJediyhttp, add your local path to sys.path
+
+
 [jedi]: http://github.com/davidhalter/jedi
 [jedi-plugin-api]: http://jedi.jedidjah.ch/en/latest/docs/plugin-api.html#module-jedi.api
 [YouCompleteMe]: http://github.com/Valloric/YouCompleteMe

--- a/jedihttp/__main__.py
+++ b/jedihttp/__main__.py
@@ -18,6 +18,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__),
                                                 '..')))
 from jedihttp import utils
 utils.add_vendor_folder_to_sys_path()
+utils.start_user_config()
 
 import logging
 import json

--- a/jedihttp/example/vimrc.py
+++ b/jedihttp/example/vimrc.py
@@ -1,0 +1,12 @@
+import sys
+import os
+
+py_folders = [
+    'common',
+]
+
+
+def onStartJedihttp():
+    work_folder = os.path.realpath(os.path.dirname(__file__))
+    for folder in py_folders:
+        sys.path.insert(0, os.path.join(work_folder, folder))

--- a/jedihttp/utils.py
+++ b/jedihttp/utils.py
@@ -25,10 +25,10 @@ def add_vendor_folder_to_sys_path():
 
 def start_user_config():
     config_py = 'vimrc.py'
-    work_folder = os.getcwdu()
+    work_folder = os.getcwd()
     while not os.path.ismount(work_folder):
         if os.path.exists(os.path.join(work_folder, config_py)):
-            sys.path.insert(0, os.path.relpath(work_folder))
+            sys.path.insert(0, os.path.realpath(work_folder))
             import vimrc
             onStartJedihttp = getattr(vimrc, 'onStartJedihttp', None)
             if onStartJedihttp:

--- a/jedihttp/utils.py
+++ b/jedihttp/utils.py
@@ -21,3 +21,17 @@ def add_vendor_folder_to_sys_path():
     for folder in os.listdir(vendor_folder):
         sys.path.insert(0, os.path.realpath(os.path.join(vendor_folder,
                                                          folder)))
+
+
+def start_user_config():
+    config_py = 'vimrc.py'
+    work_folder = os.getcwdu()
+    while not os.path.ismount(work_folder):
+        if os.path.exists(os.path.join(work_folder, config_py)):
+            sys.path.insert(0, os.path.relpath(work_folder))
+            import vimrc
+            onStartJedihttp = getattr(vimrc, 'onStartJedihttp', None)
+            if onStartJedihttp:
+                onStartJedihttp()
+            break
+        work_folder = os.path.dirname(work_folder)


### PR DESCRIPTION
allow user to custom their own project directory for JediHttp.
the python user just need add a vimrc.py in their project directory to add their custom path to python's sys.path

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vheon/jedihttp/48)
<!-- Reviewable:end -->
